### PR TITLE
Persist colorize in sessionStorage

### DIFF
--- a/js/App.js
+++ b/js/App.js
@@ -1,11 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import Inspector from './Inspector';
-import Graph from './Graph';
-import { LoadActivity } from './util';
-import Store from './Store';
+import React, { useEffect, useState } from 'react';
 import { Loader } from './Components';
+import Graph from './Graph';
+import Inspector from './Inspector';
 import sharedStateHook from './sharedStateHook';
-
+import Store from './Store';
+import { LoadActivity } from './util';
 import '/css/App.scss';
 
 export const usePane = sharedStateHook('info', 'pane');
@@ -13,7 +12,6 @@ export const useInspectorOpen = sharedStateHook(true, 'inspectorOpen');
 export const useQuery = sharedStateHook(queryFromLocation(), 'query');
 export const useModule = sharedStateHook([], 'module');
 export const useGraph = sharedStateHook([], 'graph');
-export const useColorize = sharedStateHook(false, 'colorize');
 export const useDepIncludes = sharedStateHook(['dependencies'], 'depIncludes');
 export const useExcludes = sharedStateHook([], 'excludes');
 

--- a/js/Graph.js
+++ b/js/Graph.js
@@ -1,8 +1,9 @@
 import { graphviz } from '@hpcc-js/wasm';
 import * as d3 from 'd3';
 import React, { useEffect, useState } from 'react';
+import { useSessionStorage } from 'storagehooks';
 import wasmUrl from 'url:@hpcc-js/wasm/dist/graphvizlib.wasm';
-import { activity, store, useColorize, useDepIncludes, useExcludes, useGraph, useInspectorOpen, useModule, usePane, useQuery } from './App';
+import { activity, store, useDepIncludes, useExcludes, useGraph, useInspectorOpen, useModule, usePane, useQuery } from './App';
 import { $, fetchJSON, report, tagElement } from './util';
 import '/css/Graph.scss';
 
@@ -317,7 +318,7 @@ export default function Graph(props) {
   const [, setModule] = useModule();
   const [, setGraph] = useGraph();
   const [excludes, setExcludes] = useExcludes();
-  const [colorize] = useColorize();
+  const [colorize] = useSessionStorage('colorize', false);
 
   const [graphModules, setGraphModules] = useState();
   const [zoom, setZoom] = useState(0);

--- a/js/Graph.js
+++ b/js/Graph.js
@@ -1,7 +1,7 @@
 import { graphviz } from '@hpcc-js/wasm';
 import * as d3 from 'd3';
 import React, { useEffect, useState } from 'react';
-import { useSessionStorage } from 'storagehooks';
+import { useLocalStorage } from 'storagehooks';
 import wasmUrl from 'url:@hpcc-js/wasm/dist/graphvizlib.wasm';
 import { activity, store, useDepIncludes, useExcludes, useGraph, useInspectorOpen, useModule, usePane, useQuery } from './App';
 import { $, fetchJSON, report, tagElement } from './util';
@@ -318,7 +318,7 @@ export default function Graph(props) {
   const [, setModule] = useModule();
   const [, setGraph] = useGraph();
   const [excludes, setExcludes] = useExcludes();
-  const [colorize] = useSessionStorage('colorize', false);
+  const [colorize] = useLocalStorage('colorize', false);
 
   const [graphModules, setGraphModules] = useState();
   const [zoom, setZoom] = useState(0);

--- a/js/GraphPane.js
+++ b/js/GraphPane.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 import React, { useEffect, useRef } from 'react';
-import { useSessionStorage } from 'storagehooks';
+import { useLocalStorage } from 'storagehooks';
 import { useDepIncludes, useExcludes } from './App';
 import { Toggle } from './Components';
 import { hslFor } from './Graph';
@@ -93,7 +93,7 @@ function PieGraph({ entries, ...props }) {
 export default function GraphPane({ graph, ...props }) {
   const compareEntryKey = ([a], [b]) => a < b ? -1 : a > b ? 1 : 0;
   const compareEntryValue = ([, a], [, b]) => a < b ? -1 : a > b ? 1 : 0;
-  const [colorize, setColorize] = useSessionStorage('colorize', false);
+  const [colorize, setColorize] = useLocalStorage('colorize', false);
 
   const [excludes] = useExcludes();
 

--- a/js/GraphPane.js
+++ b/js/GraphPane.js
@@ -1,10 +1,11 @@
 import * as d3 from 'd3';
 import React, { useEffect, useRef } from 'react';
-import { useColorize, useDepIncludes, useExcludes } from './App';
-import { Pane, Section, Tags, Tag } from './Inspector';
-import { simplur } from './util';
+import { useSessionStorage } from 'storagehooks';
+import { useDepIncludes, useExcludes } from './App';
 import { Toggle } from './Components';
 import { hslFor } from './Graph';
+import { Pane, Section, Tag, Tags } from './Inspector';
+import { simplur } from './util';
 import '/css/GraphPane.scss';
 
 function DepInclude({ type, ...props }) {
@@ -92,7 +93,8 @@ function PieGraph({ entries, ...props }) {
 export default function GraphPane({ graph, ...props }) {
   const compareEntryKey = ([a], [b]) => a < b ? -1 : a > b ? 1 : 0;
   const compareEntryValue = ([, a], [, b]) => a < b ? -1 : a > b ? 1 : 0;
-  const [colorize, setColorize] = useColorize();
+  const [colorize, setColorize] = useSessionStorage('colorize', false);
+
   const [excludes] = useExcludes();
 
   const occurances = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12103,6 +12103,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "storagehooks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/storagehooks/-/storagehooks-1.0.1.tgz",
+      "integrity": "sha512-ZLyHl1g+ROlYv0Sy3vKTwSkDXhSj/9+I7Ry6zULxRK/jb+PcsU9R/+w0dXtq1qCq1l4nj6gFlgcvrtMSEhNf0Q=="
+    },
     "stream-http": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "md5": "2.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "semver": "7.3.5"
+    "semver": "7.3.5",
+    "storagehooks": "1.0.1"
   },
   "description": "Visualize NPM dependency graphs (public and private!)",
   "keywords": [


### PR DESCRIPTION
Reworking #78 using `storagehooks` module to persist colorize in sessionStorage.

FWIW, `storageHooks` is my take on the "react hook for connecting component state to web storage" problemspace.  I just didn't find a module that really solved this problem properly so... yeah, wrote my own. 😢 

cc: @wenmin92