### PR TITLE
Add dark mode

### DIFF
--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -22,7 +22,7 @@
     width: 1.3em;
     padding: 0;
     margin: 0;
-    color: #333;
+    color: var(--text);
     border: solid 1px var(--bg1);
     background: var(--bg0);
     border-radius: var(--rad_sm);

--- a/css/InfoPane.scss
+++ b/css/InfoPane.scss
@@ -1,6 +1,6 @@
 #drop_target {
-  background-color: #ddd;
-  border: dashed 2px #888;
+  background-color: var(--bg2);
+  border: dashed 2px var(--text-dim);
   padding: 4em 1em;
   border-radius: var(--rad_sm);
 }

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -122,4 +122,7 @@ summary {
   overflow-x: hidden;
   border-bottom-left-radius: var(--rad_lg);
   box-shadow: inset 1px -1px 6px var(--inset-shadow-color, #d6d6d677);
+  a {
+    color: var(--highlight);
+  }
 }

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -121,5 +121,5 @@ summary {
   overflow-y: auto;
   overflow-x: hidden;
   border-bottom-left-radius: var(--rad_lg);
-  box-shadow: inset 1px -1px 6px #d6d6d677;
+  box-shadow: inset 1px -1px 6px var(--inset-shadow-color, #d6d6d677);
 }

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -122,6 +122,7 @@ summary {
   overflow-x: hidden;
   border-bottom-left-radius: var(--rad_lg);
   box-shadow: inset 1px -1px 6px var(--inset-shadow-color, #d6d6d677);
+
   a {
     color: var(--highlight);
   }

--- a/css/ModulePane.scss
+++ b/css/ModulePane.scss
@@ -15,3 +15,8 @@
   font-size: 115%;
   color: rgba(0, 0, 0, 0.5);
 }
+
+.score-bar,
+#treemap {
+  color: black;
+}

--- a/css/index.scss
+++ b/css/index.scss
@@ -33,8 +33,10 @@
 @media (prefers-color-scheme: dark) {
   html {
     background: #111;
+
     --inset-shadow-color: black;
   }
+
   .theme-lite {
     /* https://coolors.co/f1f4f4-606c38-283618-ff761a */
     --text: #f3f3f3;
@@ -44,9 +46,11 @@
     --highlight: #ff761a;
     --bg2: #333;
   }
+
   [fill="white"] {
     fill: none;
   }
+
   [stroke="black"] {
     stroke: #999;
   }
@@ -67,7 +71,6 @@ html {
   font-family: system-ui, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 10pt;
 }
-
 
 html,
 body {

--- a/css/index.scss
+++ b/css/index.scss
@@ -18,6 +18,7 @@
   --text-dim: #999;
   --bg0: #f1f4f4;
   --bg1: #d6d6d6;
+  --bg2: #ddd;
   --highlight: #e65c00;
 }
 
@@ -27,7 +28,28 @@
   --text-dim: #666;
   --bg0: #7e7e7d;
   --bg1: #383838;
-  --highlight: #ff761a;
+}
+
+@media (prefers-color-scheme: dark) {
+  html {
+    background: #111;
+    --inset-shadow-color: black;
+  }
+  .theme-lite {
+    /* https://coolors.co/f1f4f4-606c38-283618-ff761a */
+    --text: #f3f3f3;
+    --text-dim: #766;
+    --bg0: #262222;
+    --bg1: #696666;
+    --highlight: #ff761a;
+    --bg2: #333;
+  }
+  [fill="white"] {
+    fill: none;
+  }
+  [stroke="black"] {
+    stroke: #999;
+  }
 }
 
 .theme-lite,
@@ -45,6 +67,7 @@ html {
   font-family: system-ui, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 10pt;
 }
+
 
 html,
 body {

--- a/js/ModulePane.js
+++ b/js/ModulePane.js
@@ -15,7 +15,7 @@ function ScoreBar({ title, score, style }) {
 
   return <>
     <span style={{ marginRight: '1em', ...style }}>{title}</span>
-    <div class="score-bar" style={{ border: 'solid 1px #ccc', width: '200px' }} >{inner}</div>
+    <div className='score-bar' style={{ border: 'solid 1px #ccc', width: '200px' }} >{inner}</div>
   </>;
 }
 

--- a/js/ModulePane.js
+++ b/js/ModulePane.js
@@ -15,7 +15,7 @@ function ScoreBar({ title, score, style }) {
 
   return <>
     <span style={{ marginRight: '1em', ...style }}>{title}</span>
-    <div style={{ border: 'solid 1px #ccc', width: '200px' }} >{inner}</div>
+    <div class="score-bar" style={{ border: 'solid 1px #ccc', width: '200px' }} >{inner}</div>
   </>;
 }
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build": "parcel build index.html",
     "release": "standard-version",
     "start": "parcel serve index.html",
-    "test": "eslint . && stylelint css"
+    "test": "eslint . && stylelint css",
+    "fix": "eslint . --fix && stylelint css --fix"
   }
 }


### PR DESCRIPTION
This PR brings minimal changes just to add support for dark mode without affecting other parts of the code and without changing the light mode (which only has minimal changes).

The sidebar is slightly tinted red/orange, but it could be easily just brought back to a gray. Further theme improvements could be made later, but at least now we can have a workable theme without large swaths of white.

<img width="1165" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/124619239-accb3980-dea2-11eb-85d0-acd5dfb2cba6.png">


<img width="1166" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/124619231-ab9a0c80-dea2-11eb-8653-17c00d0baba0.png">