### PR TITLE
Dark mode improvements

### DIFF
--- a/js/Graph.js
+++ b/js/Graph.js
@@ -432,8 +432,8 @@ export default function Graph(props) {
     width="12" height="12"
     patternUnits="userSpaceOnUse"
     patternTransform="rotate(45 50 50)">
-    <line stroke="rgba(192,192,0,.15)" stroke-width="6px" x1="3" x2="3" y2="12"/>
-    <line stroke="rgba(0,0,0,.15)" stroke-width="6px" x1="9" x2="9" y2="12"/>
+    <line stroke="#f6f6e0" stroke-width="6px" x1="3" x2="3" y2="12"/>
+    <line stroke="#d9d9d9" stroke-width="6px" x1="9" x2="9" y2="12"/>
     </pattern>`;
 
     d3.select('#graph svg')


### PR DESCRIPTION
- Follows #91 

I'm going to leave this PR open a bit in case we see any other issues with simple fixes

## Before

<img width="246" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/125581535-f7cdbf62-e2d7-487f-92e8-13c4969677f1.png">

## After

<img width="241" alt="Screen Shot 5" src="https://user-images.githubusercontent.com/1402241/125581525-5c6fff98-d376-403b-a11c-07c9d4c42e37.png">

## Test

https://npmgraph.js.org/?q=sntp@1.0.9

👆 this URL can probably always be used to test npmgraph since it has deprecated modules and few dev dependencies
