### PR TITLE
fix: graph nodes use theme colors

### DIFF
--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -6,6 +6,17 @@
   user-select: none;
   -webkit-user-select: none;
   padding-right: var(--splitter-size);
+
+  --warning0: #f6f6e0;
+  --warning1: #d9d9d9;
+  --stub: #ff0000;
+}
+
+@media (prefers-color-scheme: dark) {
+  #graph {
+    --warning0: #101010;
+    --warning1: #666600;
+  }
 }
 
 #graph-controls {
@@ -36,23 +47,28 @@ svg {
   fill: #666;
 }
 
+pattern#warning {
+  .line0 {stroke: var(--warning0);}
+  .line1 {stroke: var(--warning1);}
+} 
+
 g .stub {
   opacity: 0.6;
 
   > path {
     stroke-dasharray: 4, 4;
-    stroke: #a00;
+    stroke: var(--stub);
   }
 }
 
 g.node {
   text {
-    fill: #444;
+    fill: var(--text);
   }
 
   path {
-    stroke: #444;
-    fill: white;
+    stroke: var(--text);
+    fill: var(--bg0);
   }
 
   &.collapsed {
@@ -62,10 +78,6 @@ g.node {
   &.selected > path {
     stroke-width: 3;
     stroke: var(--highlight);
-  }
-
-  &.selected > text {
-    fill: black;
   }
 
   &.warning > path {

--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -9,13 +9,13 @@
 
   --warning0: #f6f6e0;
   --warning1: #d9d9d9;
-  --stub: #ff0000;
+  --stub: #f00;
 }
 
 @media (prefers-color-scheme: dark) {
   #graph {
     --warning0: #101010;
-    --warning1: #666600;
+    --warning1: #660;
   }
 }
 
@@ -48,9 +48,9 @@ svg {
 }
 
 pattern#warning {
-  .line0 {stroke: var(--warning0);}
-  .line1 {stroke: var(--warning1);}
-} 
+  .line0 { stroke: var(--warning0); }
+  .line1 { stroke: var(--warning1); }
+}
 
 g .stub {
   opacity: 0.6;

--- a/js/Graph.js
+++ b/js/Graph.js
@@ -440,8 +440,8 @@ export default function Graph(props) {
     width="12" height="12"
     patternUnits="userSpaceOnUse"
     patternTransform="rotate(45 50 50)">
-    <line stroke="#f6f6e0" stroke-width="6px" x1="3" x2="3" y2="12"/>
-    <line stroke="#d9d9d9" stroke-width="6px" x1="9" x2="9" y2="12"/>
+    <line class="line0" stroke-width="6px" x1="3" x2="3" y2="12"/>
+    <line class="line1" stroke-width="6px" x1="9" x2="9" y2="12"/>
     </pattern>`;
 
     select('#graph svg')


### PR DESCRIPTION
Graph nodes were always rendering in "light" colors, which is annoying.  Now they follow user's system theme...

Before:
![image](https://user-images.githubusercontent.com/164050/140756473-47b3e2a4-0bf6-42f4-b20e-3fcac68d82ad.png)

After:
![image](https://user-images.githubusercontent.com/164050/140756380-dccc19e2-6676-4938-9158-af6c899d2dd3.png)
