### PR TITLE
fix: remove theme-lite/theme-dark abstractions

### DIFF
--- a/css/App.scss
+++ b/css/App.scss
@@ -22,8 +22,8 @@
   display: flex;
   box-sizing: border-box;
   height: 24pt;
-  color: #fff;
-  background: var(--bg-tabs) var(--bg-gradient);
+  color: var(--tabs-text);
+  background: var(--tabs-bg) var(--bg-gradient);
   border-top-left-radius: var(--rad_lg);
   border-bottom-left-radius: var(--rad_lg);
   padding-left: 10px;

--- a/css/App.scss
+++ b/css/App.scss
@@ -22,7 +22,7 @@
   display: flex;
   box-sizing: border-box;
   height: 24pt;
-  color: var(--text);
+  color: #fff;
   background: var(--bg-tabs) var(--bg-gradient);
   border-top-left-radius: var(--rad_lg);
   border-bottom-left-radius: var(--rad_lg);

--- a/css/App.scss
+++ b/css/App.scss
@@ -23,7 +23,7 @@
   box-sizing: border-box;
   height: 24pt;
   color: var(--text);
-  background: var(--bg0) var(--bg-gradient);
+  background: var(--bg-tabs) var(--bg-gradient);
   border-top-left-radius: var(--rad_lg);
   border-bottom-left-radius: var(--rad_lg);
   padding-left: 10px;

--- a/css/Components.scss
+++ b/css/Components.scss
@@ -15,8 +15,8 @@
   overflow: hidden;
   font-weight: 600;
   text-align: center;
-  color: white;
-  background: var(--bg-tabs) var(--bg-gradient);
+  color: var(--tabs-text);
+  background: var(--tabs-bg) var(--bg-gradient);
   border-top-left-radius: var(--rad_lg);
   border-bottom-left-radius: var(--rad_lg);
 

--- a/css/Components.scss
+++ b/css/Components.scss
@@ -16,7 +16,7 @@
   font-weight: 600;
   text-align: center;
   color: white;
-  background: var(--bg0) var(--bg-gradient);
+  background: var(--bg-tabs) var(--bg-gradient);
   border-top-left-radius: var(--rad_lg);
   border-bottom-left-radius: var(--rad_lg);
 

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -75,7 +75,7 @@ summary {
   flex-shrink: 0;
   display: flex;
   background: var(--bg-tabs) var(--bg-gradient);
-  color: var(--text);
+  color: #fff;
   user-select: none;
 
   > * {

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -74,7 +74,7 @@ summary {
   flex-basis: auto;
   flex-shrink: 0;
   display: flex;
-  background: var(--bg0) var(--bg-gradient);
+  background: var(--bg-tabs) var(--bg-gradient);
   color: var(--text);
   user-select: none;
 
@@ -85,7 +85,7 @@ summary {
   .tab {
     padding: 0 10px;
     cursor: pointer;
-    background: var(--bg0) var(--bg-gradient);
+    background: var(--bg-tabs) var(--bg-gradient);
     border-left: solid 1px #888;
     font-size: 12pt;
     font-weight: 600;

--- a/css/Inspector.scss
+++ b/css/Inspector.scss
@@ -74,8 +74,8 @@ summary {
   flex-basis: auto;
   flex-shrink: 0;
   display: flex;
-  background: var(--bg-tabs) var(--bg-gradient);
-  color: #fff;
+  background: var(--tabs-bg) var(--bg-gradient);
+  color: var(--tabs-text);
   user-select: none;
 
   > * {
@@ -85,7 +85,7 @@ summary {
   .tab {
     padding: 0 10px;
     cursor: pointer;
-    background: var(--bg-tabs) var(--bg-gradient);
+    background: var(--tabs-bg) var(--bg-gradient);
     border-left: solid 1px #888;
     font-size: 12pt;
     font-weight: 600;

--- a/css/index.scss
+++ b/css/index.scss
@@ -10,34 +10,19 @@
       rgba(255, 255, 255, 0.2),
       transparent 100%
     );
-}
 
-.theme-lite {
   /* https://coolors.co/020303-f1f4f4-c8d3a7-e65c00 */
   --text: #020303;
   --text-dim: #999;
   --bg0: #f1f4f4;
   --bg1: #d6d6d6;
   --bg2: #ddd;
+  --bg-tabs:#7e7e7d;
   --highlight: #e65c00;
 }
 
-.theme-dark {
-  /* https://coolors.co/f1f4f4-606c38-283618-ff761a */
-  --text: #f3f3f3;
-  --text-dim: #666;
-  --bg0: #7e7e7d;
-  --bg1: #383838;
-}
-
 @media (prefers-color-scheme: dark) {
-  html {
-    background: #111;
-
-    --inset-shadow-color: black;
-  }
-
-  .theme-lite {
+  :root {
     /* https://coolors.co/f1f4f4-606c38-283618-ff761a */
     --text: #f3f3f3;
     --text-dim: #766;
@@ -45,6 +30,11 @@
     --bg1: #696666;
     --highlight: #ff761a;
     --bg2: #333;
+    --inset-shadow-color: black;
+  }
+
+  html {
+    background: #111;
   }
 
   [fill="white"] {
@@ -54,17 +44,6 @@
   [stroke="black"] {
     stroke: #999;
   }
-}
-
-.theme-lite,
-.theme-dark {
-  /* TODO: Any vars dealing with color should should have a theme-neutral name (e.g. this should just be "--bg-gradient"), and should be defined in both themes, below */
-  --side-gradient:
-    linear-gradient(
-      to right,
-      var(--bg1) -1em,
-      transparent 0.5em
-    );
 }
 
 html {

--- a/css/index.scss
+++ b/css/index.scss
@@ -1,4 +1,6 @@
 :root {
+  color-scheme: light dark;
+
   --rad_sm: 5px;
   --rad_lg: 10px;
   --splitter-size: 2em;

--- a/css/index.scss
+++ b/css/index.scss
@@ -17,7 +17,7 @@
   --bg0: #f1f4f4;
   --bg1: #d6d6d6;
   --bg2: #ddd;
-  --bg-tabs:#7e7e7d;
+  --bg-tabs: #7e7e7d;
   --highlight: #e65c00;
 }
 

--- a/css/index.scss
+++ b/css/index.scss
@@ -17,7 +17,8 @@
   --bg0: #f1f4f4;
   --bg1: #d6d6d6;
   --bg2: #ddd;
-  --bg-tabs: #7e7e7d;
+  --tabs-bg: #7e7e7d;
+  --tabs-text: #fff;
   --highlight: #e65c00;
 }
 
@@ -28,8 +29,8 @@
     --text-dim: #766;
     --bg0: #262222;
     --bg1: #696666;
-    --highlight: #ff761a;
     --bg2: #333;
+    --highlight: #ff761a;
     --inset-shadow-color: black;
   }
 

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
   </head>
 
   <body>
-    <div id='app' class='theme-lite'></div>
+    <div id='app' />
 
 <script src="https://d2wy8f7a9ursnm.cloudfront.net/v5/bugsnag.min.js"></script>
 

--- a/js/App.js
+++ b/js/App.js
@@ -18,7 +18,7 @@ export const useIncludeDev = sharedStateHook(false, 'includeDev');
 export const useExcludes = sharedStateHook([], 'excludes');
 
 function Splitter({ onClick, isOpen }) {
-  return <div id='splitter' className='theme-dark bright-hover' onClick={onClick}>{isOpen ? '\u{25b6}' : '\u{25c0}'}</div>;
+  return <div id='splitter' className='bright-hover' onClick={onClick}>{isOpen ? '\u{25b6}' : '\u{25c0}'}</div>;
 }
 
 // Parse `q` query param from browser location

--- a/js/Components.js
+++ b/js/Components.js
@@ -3,7 +3,7 @@ import React from 'react';
 import '/css/Components.scss';
 
 export function Loader({ activity, ...props }) {
-  return <div className='loader theme-dark'>
+  return <div className='loader'>
     <div className='bg' />
     {activity.title} ...
   </div>;

--- a/js/Inspector.js
+++ b/js/Inspector.js
@@ -46,7 +46,7 @@ export function Section({ title, children, open = true, style, ...props }) {
 }
 
 export function Pane({ children, ...props }) {
-  return <div className='pane theme-lite' {...props}>{children}</div>;
+  return <div className='pane' {...props}>{children}</div>;
 }
 
 export function Tags({ children, style, ...props }) {
@@ -72,7 +72,7 @@ function Tab({ active, children, ...props }) {
   return <div className={`tab bright-hover ${active ? 'active' : ''}`} {...props}>{children}</div>;
 }
 
-export default function Inspector({ className, ...props }) {
+export default function Inspector(props) {
   const [query, setQuery] = useQuery();
   const [pane, setPane] = usePane();
   const [module] = useModule();
@@ -104,8 +104,8 @@ export default function Inspector({ className, ...props }) {
     setQuery(query);
   }
 
-  return <div id='inspector' className={`theme-lite ${className}`} {...props} >
-      <div id='tabs' className='theme-dark'>
+  return <div id='inspector' {...props} >
+      <div id='tabs'>
         <Tab active={pane == 'module'} onClick={() => setPane('module')}>Module</Tab>
         <Tab active={pane == 'graph'} onClick={() => setPane('graph')}>Graph</Tab>
         <Tab active={pane == 'info'} onClick={() => setPane('info')}>{'\u{24d8}'}</Tab>


### PR DESCRIPTION
This should not result in any changes to the UI.  Just getting rid of the last vestiges of the theme-dark / theme-light that I had originally used for theming the UI.  The only real change required for this was to create the `--bg-tabs` var to abstract out the background color used by the tabs, splitter, and loader.

Everything else here is just cleanup that flows from the above.