### PR TITLE
fix: minor theme color issues

### DIFF
--- a/css/Graph.scss
+++ b/css/Graph.scss
@@ -89,13 +89,22 @@ g.node {
   }
 }
 
-g.edge.selected {
-  > path {
-    stroke-width: 2;
-    stroke: var(--highlight);
+g.edge {
+  > path { // stylelint-disable-line no-descending-specificity
+    stroke: var(--text);
   }
 
   > polygon {
+    stroke: var(--text);
+    fill: var(--text);
+  }
+
+  &.selected > path {
+    stroke-width: 3;
+    stroke: var(--highlight);
+  }
+
+  &.selected > polygon {
     stroke: var(--highlight);
     fill: var(--highlight);
   }

--- a/css/index.scss
+++ b/css/index.scss
@@ -35,18 +35,6 @@
     --highlight: #ff761a;
     --inset-shadow-color: black;
   }
-
-  html {
-    background: #111;
-  }
-
-  [fill="white"] {
-    fill: none;
-  }
-
-  [stroke="black"] {
-    stroke: #999;
-  }
 }
 
 html {

--- a/css/index.scss
+++ b/css/index.scss
@@ -26,6 +26,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+    background-color: #111;
+
     /* https://coolors.co/f1f4f4-606c38-283618-ff761a */
     --text: #f3f3f3;
     --text-dim: #766;

--- a/js/Graph.js
+++ b/js/Graph.js
@@ -428,6 +428,9 @@ export default function Graph(props) {
     svgDom = svgDom.children[0];
     svgDom.remove();
 
+    // Remove background element so page background shows thru
+    $(svgDom, '.graph > polygon').remove();
+
     applyZoom(svgDom);
 
     // Inject into DOM


### PR DESCRIPTION
* arrowheads were not filled in in dark mode (see below)
* remove background `polygon` in SVG to allow page background to show through
* remove `html` `background` CSS so the user-agent background is used
* remove the `[fill=...]` and `[stroke=...]` CSS attribute-hacks for tweaking SVG fill and stroke colors, as they no longer apply to anything.

Before:
<img width="441" alt="CleanShot 2021-11-09 at 06 56 23@2x" src="https://user-images.githubusercontent.com/164050/140947557-ed4ce77a-94c1-4dd0-815f-5ffe94d63ec1.png">

After:
<img width="438" alt="CleanShot 2021-11-09 at 06 55 19@2x" src="https://user-images.githubusercontent.com/164050/140947344-ac1992c8-ac3e-4a06-ae40-127050f33112.png">
