### PR TITLE
fix: broken request error handling

### DIFF
--- a/js/Store.ts
+++ b/js/Store.ts
@@ -2,7 +2,7 @@ import doesSatisfySemver from 'semver/functions/satisfies';
 import isSemverValid from 'semver/functions/valid';
 import Module, { moduleKey } from './Module';
 import { ModuleInfo } from './types';
-import { fetchJSON, LoadActivity, report } from './util';
+import { fetchJSON, HttpError, LoadActivity, report } from './util';
 
 class Store {
   activity: LoadActivity;
@@ -104,10 +104,7 @@ class Store {
       );
       req = this.requestCache[reqPath] = fetchJSON<ModuleInfo>(
         `https://registry.npmjs.cf/${reqPath}`
-      )
-        // Errors get turned into stub modules, below
-        .catch(err => err)
-        .finally(finish);
+      ).finally(finish);
     }
 
     let body: ModuleInfo;
@@ -118,12 +115,14 @@ class Store {
       failure = err;
     }
 
-    if (!body) {
+    if (failure) {
+      if (failure instanceof HttpError) {
+        failure.message = `Error getting module from NPM (status: ${failure.code})`;
+      }
+    } else if (!body) {
       failure = Error('No info provided by NPM repo');
     } else if (typeof body != 'object') {
-      failure = Error(
-        'Data provided by NPM repo is not in the expected format'
-      );
+      failure = Error('Data not in expected format');
     } else if (body.unpublished) {
       failure = Error('Module is unpublished');
     } else if (body.versions) {

--- a/js/Store.ts
+++ b/js/Store.ts
@@ -117,14 +117,14 @@ class Store {
 
     if (failure) {
       if (failure instanceof HttpError) {
-        failure.message = `Error getting module from NPM (status: ${failure.code})`;
+        failure.message = `Request for module data failed (status: ${failure.code})`;
       }
     } else if (!body) {
-      failure = Error('No info provided by NPM repo');
+      failure = Error('Empty module data');
     } else if (typeof body != 'object') {
-      failure = Error('Data not in expected format');
+      failure = Error('Unexpected module data structure');
     } else if (body.unpublished) {
-      failure = Error('Module is unpublished');
+      failure = Error('This module is unpublished');
     } else if (body.versions) {
       // Available versions (most recent first)
       const versions = Object.values(body.versions).reverse();

--- a/js/util.ts
+++ b/js/util.ts
@@ -205,7 +205,9 @@ export class LoadActivity {
  */
 export function fetchJSON<T>(...args: [string, RequestInit?]): Promise<T> {
   const p = window.fetch(...args).then(res => {
-    if (!res.ok) throw new HttpError(res.status);
+    if (!res.ok) {
+      return Promise.reject(new HttpError(res.status));
+    }
     return res.json();
   });
 


### PR DESCRIPTION
One of my more recent PRs (too lazy to track down which one) introduced a bug that caused rendering to break if one of the modules was not found in the NPM repo.  This was due to failed repo requests *not* resulting in a stub module, which led to graphs that looked like this:
![CleanShot 2021-12-10 at 09 19 39@2x](https://user-images.githubusercontent.com/164050/145615255-776133aa-8a03-4870-93ca-119f1437a3d0.png)

This fix returns the prior (correct) behavior, and also improves error messaging shown in the module pain in the event there is an error. E.g.:

![CleanShot 2021-12-10 at 09 21 52@2x](https://user-images.githubusercontent.com/164050/145615461-2d5b047d-f598-4a1f-9f85-71664b39967c.png)

To test: Show any graph that has a non-existent module.  E.g. https://npmgraph.js.org/?q=cgm-remote-monitor