### PR TITLE
fix: react hook errors, npmsio types

### DIFF
--- a/js/Inspector.tsx
+++ b/js/Inspector.tsx
@@ -67,7 +67,7 @@ export function Section({
   );
 }
 
-export function Pane({ children, ...props }) {
+export function Pane({ children, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div className="pane" {...props}>
       {children}
@@ -129,7 +129,7 @@ export function Tag({
   );
 }
 
-function Tab({ active, children, ...props }) {
+function Tab({ active, children, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div className={`tab bright-hover ${active ? 'active' : ''}`} {...props}>
       {children}

--- a/js/types.ts
+++ b/js/types.ts
@@ -47,3 +47,14 @@ export type GraphState = {
   // Upstream dependency types for each module
   referenceTypes: Map<string, Set<string>>;
 };
+
+export type npmsioResponse = {
+  score: {
+    final: number;
+    detail: {
+      quality: number;
+      popularity: number;
+      maintenance: number;
+    };
+  };
+};


### PR DESCRIPTION
Fixing another error that's been showing up in Bugsnag.  Basically the issue was that React hooks were conditionally called in `ModulePane`, which would break the module pane when you clicked between a normal module vs. a stub module in the graph pane, like so...

![CleanShot 2021-12-12 at 06 27 02](https://user-images.githubusercontent.com/164050/145716457-f9b8dfe3-6c16-41e9-a3b0-259024364a26.gif)

Fix was to just move some code around.

Unrelated: Typescript was complaining about some typing issues.  Fixed those.