### PR TITLE
Use lowercase for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# NPMGraph
+# npmgraph
 
-A tool for exploring NPM modules and dependencies.
+A tool for exploring npm modules and dependencies.
 
 **Available online at https://npmgraph.js.org/.**
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     />
     <link href="/css/index.scss" rel="stylesheet" />
 
-    <title>NPMGraph - Visualize NPM Module Dependencies</title>
+    <title>npmgraph - Visualize npm Module Dependencies</title>
   </head>
 
   <body>

--- a/js/Graph.tsx
+++ b/js/Graph.tsx
@@ -339,7 +339,7 @@ function colorizeGraph(svg: SVGSVGElement, colorize: string) {
       el => store.cachedEntry(el.dataset.module).name
     );
 
-    // NPMS.io limits to 250 packages
+    // npms.io limits to 250 packages
     const reqs = [];
     const MAX_PACKAGES = 250;
     while (packageNames.length) {
@@ -609,7 +609,7 @@ export default function Graph() {
   // (Re)apply zoom if/when it changes
   useEffect(applyZoom, [zoom, domSignal]);
 
-  $('title').innerText = `NPMGraph - ${query.join(', ')}`;
+  $('title').innerText = `npmgraph - ${query.join(', ')}`;
 
   return (
     <div id="graph" onClick={handleGraphClick}>

--- a/js/GraphPane.tsx
+++ b/js/GraphPane.tsx
@@ -149,10 +149,10 @@ export default function GraphPane({ graph, ...props }) {
         >
           <option value="">Nothing (uncolored)</option>
 
-          <option value="overall"> NPMS.io overall score</option>
-          <option value="quality"> NPMS.io quality score</option>
-          <option value="popularity"> NPMS.io popularity score</option>
-          <option value="maintenance">NPMS.io maintenance score</option>
+          <option value="overall"> npms.io overall score</option>
+          <option value="quality"> npms.io quality score</option>
+          <option value="popularity"> npms.io popularity score</option>
+          <option value="maintenance">npms.io maintenance score</option>
 
           <option value="bus"># of maintainers</option>
         </select>

--- a/js/InfoPane.tsx
+++ b/js/InfoPane.tsx
@@ -100,7 +100,7 @@ export default function InfoPane(props) {
       />
 
       <p>
-        Enter NPM module name here{' '}
+        Enter npm module name here{' '}
         <i className="material-icons">arrow_upward</i> to see the dependency
         graph. Separate multiple module names with commas (e.g.{' '}
         <a href="?q=mocha, chalk, rimraf">&quot;mocha, chalk, rimraf&quot;</a>).

--- a/js/Inspector.tsx
+++ b/js/Inspector.tsx
@@ -204,7 +204,7 @@ export default function Inspector(props) {
       {paneComponent}
 
       <footer>
-        {'\xa9'} NPMGraph Contributors &mdash;{' '}
+        {'\xa9'} npmgraph Contributors &mdash;{' '}
         <ExternalLink id="github" href="https://github.com/npmgraph/npmgraph">
           GitHub
         </ExternalLink>{' '}

--- a/js/ModulePane.tsx
+++ b/js/ModulePane.tsx
@@ -195,7 +195,7 @@ export default function ModulePane({ module, ...props }) {
       <p>{pkg?.description}</p>
 
       <ExternalLink href={module.npmLink} style={{ marginRight: '1em' }}>
-        NPM
+        npm
       </ExternalLink>
       {module.repoLink ? (
         <ExternalLink href={module.repoLink} style={{ marginRight: '1em' }}>
@@ -236,7 +236,7 @@ export default function ModulePane({ module, ...props }) {
         ) : null}
       </Section>
 
-      <Section title="NPMS.io Score">
+      <Section title="npms.io Score">
         {!npmsInfo ? (
           'Loading'
         ) : npmsInfo instanceof Error ? (

--- a/js/types.ts
+++ b/js/types.ts
@@ -8,7 +8,7 @@ export type OldLicense = {
   url: string;
 };
 
-// TODO: Actual schema for NPM module info is pretty complex.  This is just a
+// TODO: Actual schema for npm module info is pretty complex.  This is just a
 // quick pass at the types we currently care about
 export type ModuleInfo = {
   version: string;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "18.0.0",
     "semver": "7.3.7"
   },
-  "description": "Visualize NPM dependency graphs (public and private!)",
+  "description": "Visualize npm dependency graphs (public and private!)",
   "keywords": [
     "npm",
     "dependencies",


### PR DESCRIPTION
Just a minor capitalization fix: `NPM` -> `npm`

npm should never be capitalized:
https://github.com/npm/cli#is-it-npm-or-npm-or-npm

Also, npms.io does not use uppercase characters:
https://npms.io/about