### PR TITLE
fix: hash and search param behavior when navigating

### DIFF
--- a/js/components/App.tsx
+++ b/js/components/App.tsx
@@ -15,12 +15,12 @@ export const [useGraph] = sharedStateHook(null as GraphState | null, 'graph');
 export const [useExcludes] = sharedStateHook([] as string[], 'excludes');
 
 export function useQuery() {
-  const [val, setVal] = useSearchParam('q');
-  const moduleKeys = val.split(/[, ]+/).filter(Boolean);
+  const [queryString, setQueryString] = useSearchParam('q');
+  const moduleKeys = queryString.split(/[, ]+/).filter(Boolean);
   return [
     moduleKeys,
     function setQuery(moduleKeys: string[] = []) {
-      setVal(moduleKeys.join(','));
+      setQueryString(moduleKeys.join(','), true);
     },
   ] as const;
 }

--- a/js/components/QueryLink.tsx
+++ b/js/components/QueryLink.tsx
@@ -5,14 +5,13 @@ import { useQuery } from './App.js';
 
 export function QueryLink({ query }: { query: string | string[] }) {
   const [, setQuery] = useQuery();
-  const [location, setLocation] = useLocation();
+  const [location] = useLocation();
+
   const queries = Array.isArray(query) ? query : [query];
 
   function onClick(e: React.MouseEvent) {
-    const target = e.target as HTMLAnchorElement;
     e.preventDefault();
     setQuery(queries);
-    setLocation(target.href);
   }
 
   const url = new URL(location);

--- a/js/util/sharedStateHook.ts
+++ b/js/util/sharedStateHook.ts
@@ -35,16 +35,16 @@ import { useEffect, useState } from 'react';
  *    that depend on just one of the properties in a context, but that rerender when
  *    *any* property is changed.
  *
- * @param {any} defaultValue
+ * @param {any} initialValue
  * @returns {Function} React hook function
  */
 
 export default function sharedStateHook<T>(
-  defaultValue: T,
+  initialValue: T,
   name?: string, // eslint-disable-line @typescript-eslint/no-unused-vars
 ) {
   const setters = new Set<(v: T) => void>();
-  let sharedValue: T = defaultValue;
+  let sharedValue: T = initialValue;
   const notifySetters = (value: T) => {
     sharedValue = value;
     for (const setter of setters) setter(value);

--- a/js/util/useHashParam.ts
+++ b/js/util/useHashParam.ts
@@ -1,18 +1,21 @@
 import useLocation from './useLocation.js';
 
 export default function useHashParam<T extends string>(
-  hashProp: string,
+  paramName: string,
 ): readonly [val: T, set: (val: T) => void] {
   const [location, setLocation] = useLocation();
   const params = new URLSearchParams(location.hash.replace(/^#/, ''));
-  const value = (params.get(hashProp) ?? '') as T;
+  const value = (params.get(paramName) ?? '') as T;
 
   const setValue = (val: T) => {
+    if (val === value) return;
+    console.log('Setting hash', paramName, 'to', val);
+
     // Update state value
     if (!val) {
-      params.delete(hashProp);
+      params.delete(paramName);
     } else {
-      params.set(hashProp, val);
+      params.set(paramName, val);
     }
 
     // Update page

--- a/js/util/useLocation.ts
+++ b/js/util/useLocation.ts
@@ -13,10 +13,10 @@ export default function useLocation() {
       val = new URL(val);
     }
 
+    if (val.href === location.href) return;
+
     // Dont' allow direct manipulation
     Object.freeze(val);
-
-    if (val.href === location.href) return;
 
     // Update state value
     if (replace) {

--- a/js/util/useSearchParam.ts
+++ b/js/util/useSearchParam.ts
@@ -1,24 +1,27 @@
 import useLocation from './useLocation.js';
 
-export default function useSearchParam<T extends string>(
-  searchProp: string,
-): readonly [val: T, set: (val: T) => void] {
+export default function useSearchParam<T extends string>(paramName: string) {
   const [location, setLocation] = useLocation();
   const params = new URLSearchParams(location.search);
-  const value = (params.get(searchProp) ?? '') as T;
+  const value = (params.get(paramName) ?? '') as T;
 
-  const setValue = (val: T) => {
+  const setValue = (val: T, resetHash = false) => {
+    if (val === value) return;
+    console.log('Setting search', paramName, 'to', val);
     // Update state value
     if (!val) {
-      params.delete(searchProp);
+      params.delete(paramName);
     } else {
-      params.set(searchProp, val);
+      params.set(paramName, val);
     }
 
     // Update page
     const url = new URL(location);
     url.search = params.toString();
-    setLocation(url, true);
+
+    if (resetHash) url.hash = '';
+
+    setLocation(url);
   };
 
   return [value, setValue] as const;


### PR DESCRIPTION
Feels like I've finally got the overall behavior of the app when navigating figured out. Rules are basically this...
* Changing the query (entry points for graph) pushes a new entry on browser history.  This also resets the `location#hash`, which is where the view configuration is stored.
* Changing the view configuration (`location.hash`) *replaces* the current history entry

The end result is that you can go back and forth between various graphs in your history and change the view configuration.  And, because none of this actually refreshes the page, the in-memory module and request caches stay intact.  And because the latest version of graphviz is really performant, it all feels really snappy now.