### PR TITLE
fix: unnamed / unversioned module handling

### DIFF
--- a/components/InfoPane/FileUploadControl.tsx
+++ b/components/InfoPane/FileUploadControl.tsx
@@ -8,6 +8,7 @@ import {
   PARAM_QUERY,
   UNNAMED_PACKAGE,
 } from '../../lib/constants.js';
+import { flash } from '../../lib/flash.js';
 import useLocation from '../../lib/useLocation.js';
 import './FileUploadControl.scss';
 
@@ -58,8 +59,15 @@ export default function FileUploadControl(props: HTMLProps<HTMLLabelElement>) {
       reader.readAsText(file);
     });
 
+    console.log(file);
     // Parse module and insert into cache
-    const pkg: PackageJson = JSON.parse(content);
+    let pkg: PackageJson;
+    try {
+      pkg = JSON.parse(content);
+    } catch (err) {
+      flash(`${file.name} is not a valid JSON file`);
+      return;
+    }
 
     pkg.name ??= UNNAMED_PACKAGE;
 

--- a/components/InfoPane/FileUploadControl.tsx
+++ b/components/InfoPane/FileUploadControl.tsx
@@ -3,7 +3,11 @@ import React, { HTMLProps } from 'react';
 import { ModulePackage } from '../../lib/Module.js';
 import { cacheLocalPackage } from '../../lib/ModuleCache.js';
 import URLPlus from '../../lib/URLPlus.js';
-import { PARAM_PACKAGES, PARAM_QUERY } from '../../lib/constants.js';
+import {
+  PARAM_PACKAGES,
+  PARAM_QUERY,
+  UNNAMED_PACKAGE,
+} from '../../lib/constants.js';
 import useLocation from '../../lib/useLocation.js';
 import './FileUploadControl.scss';
 
@@ -57,7 +61,7 @@ export default function FileUploadControl(props: HTMLProps<HTMLLabelElement>) {
     // Parse module and insert into cache
     const pkg: PackageJson = JSON.parse(content);
 
-    pkg.name ??= 'Unnamed package';
+    pkg.name ??= UNNAMED_PACKAGE;
 
     // Note: cacheLocalPackage() sanitizes pkg.keys in-place(!)
     const module = cacheLocalPackage(pkg as ModulePackage);

--- a/components/InfoPane/QueryInput.tsx
+++ b/components/InfoPane/QueryInput.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLProps, useState } from 'react';
 import URLPlus from '../../lib/URLPlus.js';
-import { PARAM_PACKAGES } from '../../lib/constants.js';
+import { PARAM_PACKAGES, UNNAMED_PACKAGE } from '../../lib/constants.js';
 import { isDefined } from '../../lib/guards.js';
 import useLocation from '../../lib/useLocation.js';
 import { useQuery } from '../../lib/useQuery.js';
@@ -11,7 +11,11 @@ export default function QueryInput(props: HTMLProps<HTMLInputElement>) {
   const [query] = useQuery();
   const [location, setLocation] = useLocation();
 
-  const [value, setValue] = useState(query.join(', '));
+  const initialValue = query.join(', ');
+
+  const [value, setValue] = useState(
+    initialValue === UNNAMED_PACKAGE ? '' : initialValue,
+  );
   let valueAsURL: URL | undefined = undefined;
 
   try {

--- a/components/InfoPane/QueryInput.tsx
+++ b/components/InfoPane/QueryInput.tsx
@@ -14,7 +14,7 @@ export default function QueryInput(props: HTMLProps<HTMLInputElement>) {
   const initialValue = query.join(', ');
 
   const [value, setValue] = useState(
-    initialValue === UNNAMED_PACKAGE ? '' : initialValue,
+    initialValue.startsWith(UNNAMED_PACKAGE) ? '' : initialValue,
   );
   let valueAsURL: URL | undefined = undefined;
 

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -47,6 +47,10 @@ export default class Module {
   // TODO: This should take either ModulePackage or PackageJSON... but need to
   // be clear about the differences between the two!
   constructor(pkg: ModulePackage) {
+    if (!pkg.name) {
+      throw new Error(`Package name is required`);
+    }
+
     if (!pkg.maintainers) {
       pkg.maintainers = [];
     } else if (!Array.isArray(pkg.maintainers)) {

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -248,24 +248,6 @@ export function sanitizePackageKeys(pkg: PackageJson) {
 export function cacheLocalPackage(pkg: ModulePackage) {
   pkg = sanitizePackageKeys(pkg) as ModulePackage;
 
-  // Construct a local module for the package
-  if (!pkg.name) pkg.name = '(upload)';
-  if (!pkg.version) {
-    // Create version string.  Sadly, there isn't a great semver-compliant
-    // scheme out there.  CalVer is a thing but kind of a mess, so I'm using
-    // this format, instead: <year>.<dayOfYear>.<secondsOfDay>
-    //
-    // https://github.com/mahmoud/calver/issues/created_by/broofa
-    const now = new Date();
-    const year = now.getUTCFullYear();
-    let seconds = (Number(now) - Number(new Date(year, 1, 1))) / 1000;
-    const dayOfYear = Math.floor(seconds / 86400);
-    seconds -= dayOfYear * 86400;
-    const version = `${year}.${dayOfYear}.${Math.floor(seconds)}`;
-
-    pkg.version = version;
-  }
-
   pkg._local = true;
 
   const module = new Module(pkg);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -23,8 +23,10 @@ export const PARAM_SELECTION = 'select';
 export const PARAM_VIEW_MODE = 'view';
 export const PARAM_ZOOM = 'zoom';
 
+export const UNNAMED_PACKAGE = 'Unnamed package';
+
+export const VIEW_MODE_CLOSED = 'closed';
+
 export const ZOOM_FIT_HEIGHT = 'h';
 export const ZOOM_FIT_WIDTH = 'w';
 export const ZOOM_NONE = '';
-
-export const VIEW_MODE_CLOSED = 'closed';

--- a/lib/useQuery.tsx
+++ b/lib/useQuery.tsx
@@ -3,7 +3,7 @@ import useSearchParam from './useSearchParam.js';
 
 export function useQuery() {
   const [queryString, setQueryString] = useSearchParam(PARAM_QUERY);
-  const moduleKeys = queryString.split(/[, ]+/).filter(Boolean);
+  const moduleKeys = queryString.split(/\s*,\s*/).filter(Boolean);
   return [
     moduleKeys,
     function setQuery(moduleKeys: string[] = [], replace = false) {


### PR DESCRIPTION
https://npmgraph-git-unnamedpackages-npmgraph.vercel.app/

Module w/ no name or version:
https://npmgraph-git-unnamedpackages-npmgraph.vercel.app/?q=Unnamed+package#packages=%5B%7B%22dependencies%22%3A%7B%22send%22%3A%220.18.0%22%7D%2C%22name%22%3A%22Unnamed+package%22%7D%5D

Module w/ name, no version: 
https://npmgraph-git-unnamedpackages-npmgraph.vercel.app/?q=my+silly+name#packages=%5B%7B%22name%22%3A%22my+silly+name%22%2C%22dependencies%22%3A%7B%22send%22%3A%220.18.0%22%7D%7D%5D
Module w/ version, no name:
https://npmgraph-git-unnamedpackages-npmgraph.vercel.app/?q=Unnamed+package%40my+silly+version#packages=%5B%7B%22version%22%3A%22my+silly+version%22%2C%22dependencies%22%3A%7B%22send%22%3A%220.18.0%22%7D%2C%22name%22%3A%22Unnamed+package%22%7D%5D
