### PR TITLE
fix: closes #158

### DIFF
--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -270,8 +270,6 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
   // (Re)apply zoom if/when it changes
   useEffect(applyZoom, [zoom, domSignal]);
 
-  $('title').innerText = `npmgraph - ${query.join(', ')}`;
-
   return (
     <div id="graph" onClick={handleGraphClick}>
       <div id="graph-controls">

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     />
     <link href="./index.scss" rel="stylesheet" />
 
-    <title>npmgraph - Visualize npm Module Dependencies</title>
+    <title>npmgraph - NPM Dependency Diagrams</title>
   </head>
 
   <body>

--- a/lib/DiagramTitle.tsx
+++ b/lib/DiagramTitle.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from './useQuery.js';
+
+export function DiagramTitle({ defaultTitle }: { defaultTitle: string }) {
+  const [query] = useQuery();
+
+  if (!query.length) return defaultTitle;
+  return `npmgraph - Dependencies for ${query.join(', ')}`;
+}

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -3,6 +3,7 @@ import './bugsnag.js'; // Initialize ASAP!
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App, { setActivityForApp } from '../components/App.js';
+import { DiagramTitle } from './DiagramTitle.js';
 import LoadActivity from './LoadActivity.js';
 import { syncPackagesHash } from './ModuleCache.js';
 import { setActivityForRequestCache } from './fetchJSON.js';
@@ -30,6 +31,9 @@ window.onload = function () {
   setActivityForRequestCache(activity);
   setActivityForApp(activity);
 
-  const root = createRoot(document.querySelector('#app') as HTMLDivElement);
-  root.render(<App />);
+  const appEl = document.querySelector('#app') as HTMLDivElement;
+  createRoot(appEl).render(<App />);
+
+  const titleEl = document.querySelector('title') as HTMLTitleElement;
+  createRoot(titleEl).render(<DiagramTitle defaultTitle={titleEl.innerText} />);
 };


### PR DESCRIPTION
Keeps the initial window title as the default title to use when there's no active query.  Also moves title logic into it's own root react element, because why not. :-)