### PR TITLE
refactor: use custom SVG icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 .vscode
 !package-lock.json
+art/**/*.svg.*.svg  # inkscape backup files

--- a/art/README.md
+++ b/art/README.md
@@ -1,0 +1,15 @@
+"icons.svg" holds the artwork for the various icons defined in
+components/Icons.tsx. It is an Inkscape document that contains a layer per
+icon. Within that document (i.e. in Inkscape), we expect each icon to be a
+single path.
+
+- Icons should fit w/in the 16x16px dimensions of the document
+- For now, we're leaving ~1/2px padding around the path of the icon (to allow for 1-px stroke)
+
+To get the path string for an icon:
+
+- select the icon path
+- Open the Edit -> XML Editor
+- Select the `d` property
+- Note: The XML tool has a nice little utility for rounding path coordinates to vaarious precisions. This is helpful in cleaning up the path string
+- Copy/paste the path string, removing all newlines.

--- a/art/icons.svg
+++ b/art/icons.svg
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   sodipodi:docname="icons.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:zoom="60.4375"
+     inkscape:cx="8"
+     inkscape:cy="7.991727"
+     inkscape:window-width="1392"
+     inkscape:window-height="1261"
+     inkscape:window-x="662"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="4"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1">
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect6"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 2.3316716,1.5875 6.1349944,3.9687499 2.3316716,6.3499997"
+       copytype="single_stretched"
+       prop_scale="0.51455402"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect5"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 2.1166665,2.1166666 4.2333331,0.79374997 6.3499996,2.1166666"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect4"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 2.3316716,0.79374996 H 6.1349944 V 7.672919 H 2.3316716"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect3"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 0.26458332,1.5875 V 0.26458332 H 8.202083 V 1.5875"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect2"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 0.26458332,1.5875 V 0.26458332 H 8.202083 V 1.5875"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect3-5"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 0.26458332,1.5875 V 0.26458332 H 8.202083 V 1.5875"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect5-2"
+       is_visible="true"
+       lpeversion="1"
+       pattern="M 2.1166665,2.1166666 4.2333331,0.79374997 6.3499996,2.1166666"
+       copytype="single_stretched"
+       prop_scale="2.8749527"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       hide_knot="false"
+       fuse_tolerance="0" />
+  </defs>
+  <g
+     inkscape:label="Horizontal Zoom"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline">
+    <path
+       id="path2"
+       sodipodi:nodetypes="cccccccccccccccc"
+       inkscape:label="path"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="M 13,8 H 3 M 5,5 3,8 5,11 m 6,-6 2,3 -2,3 M 4,1 H 1 V 15 H 4 M 12,1 h 3 v 14 h -3" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Vertical Zoom"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <path
+       id="path2-3"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8,3 v 10 m -3,-2 3,2 3,-2 M 5,5 8,3 11,5 M 1,12 v 3 H 15 V 12 M 1,4 V 1 h 14 v 3"
+       sodipodi:nodetypes="cccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Download"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <path
+       id="path8"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 10,11 c 0,0 0.0057,2.426034 2,4 H 4 c 1.9148371,-1.051223 2,-4 2,-4 m 5,-9 h 4 v 9 H 1 V 2 H 5 M 10,6 8,8 6,6 M 8,1 v 7"
+       sodipodi:nodetypes="ccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="g1"
+     inkscape:label="Github"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <path
+       id="path1"
+       style="display:inline;fill:#000000;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.9882455,1.0000001 c 3.9547795,0 7.1579705,3.2031925 7.1579705,7.1579722 a 7.1696041,7.1696041 0 0 1 -4.876368,6.7911257 c -0.3578975,0.07159 -0.4921095,-0.152106 -0.4921095,-0.340004 0,-0.24158 0.0089,-1.011062 0.0089,-1.968442 0,-0.67106 -0.223687,-1.100539 -0.483163,-1.324225 1.5926495,-0.178949 3.2658265,-0.787376 3.2658265,-3.5342482 0,-0.787377 -0.277372,-1.4226472 -0.733693,-1.9237051 0.07159,-0.1789492 0.322109,-0.9126414 -0.07158,-1.8968627 0,0 -0.599479,-0.1968443 -1.9684405,0.7336922 -0.572593,-0.1610544 -1.181021,-0.2415816 -1.789449,-0.2415816 -0.608427,0 -1.216855,0.080527 -1.789493,0.2415816 -1.368962,-0.921589 -1.968442,-0.7336922 -1.968442,-0.7336922 -0.393688,0.9842213 -0.143159,1.7179135 -0.07158,1.8968627 -0.45632,0.5010579 -0.733692,1.1452756 -0.733692,1.9237051 0,2.7379252 1.664229,3.3552992 3.256878,3.5342482 -0.205792,0.17895 -0.393689,0.492111 -0.456321,0.957379 -0.411584,0.187897 -1.440542,0.492111 -2.08476,-0.590531 -0.134212,-0.214741 -0.536847,-0.74264 -1.100538,-0.733694 -0.59948,0.009 -0.241581,0.340004 0.0089,0.474216 0.304214,0.170002 0.653165,0.805273 0.733692,1.011064 0.14316,0.402635 0.608428,1.172118 2.406869,0.841061 0,0.599481 0.0089,1.163171 0.0089,1.333172 0,0.187898 -0.134213,0.402637 -0.492112,0.340004 A 7.1534985,7.1534985 0 0 1 0.8302724,8.1579723 c 0,-3.9547797 3.2031931,-7.1579722 7.1579731,-7.1579722 z"
+       sodipodi:nodetypes="cccccccccccccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer4"
+     inkscape:label="ExternalLink"
+     style="display:none"
+     sodipodi:insensitive="true">
+    <path
+       id="path11"
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round"
+       d="m 13,7 v 7 H 2 V 3 h 7 m 2,-2 h 4 v 4 z m 2,2 -5,5" />
+  </g>
+</svg>

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLProps } from 'react';
+import { OffsiteLinkIcon } from './Icons.js';
 
 export function ExternalLink({
   href,
@@ -15,7 +16,7 @@ export function ExternalLink({
       {...props}
     >
       {children}
-      <span className="material-icons">open_in_new</span>
+      <OffsiteLinkIcon style={{ marginLeft: '0.25em' }} />
     </a>
   );
 }

--- a/components/GraphDiagram/GraphDiagram.scss
+++ b/components/GraphDiagram/GraphDiagram.scss
@@ -49,7 +49,7 @@
   }
 }
 
-svg {
+svg#graph-diagram {
   fill: #666;
 }
 

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -107,7 +107,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
 
   function applyZoom() {
     const graphEl = $<HTMLDivElement>('#graph')[0];
-    const svg = $<SVGSVGElement>('#graph svg')[0];
+    const svg = getDiagramElement();
     if (!svg) return;
 
     // Note: Not using svg.getBBox() here because (for some reason???) it's
@@ -188,10 +188,11 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
       // Remove background element so page background shows thru
       $(svgDom, '.graph > polygon').remove();
       svgDom.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+      svgDom.id = 'graph-diagram';
 
       // Inject into DOM
       const el = $('#graph');
-      select('#graph svg').remove();
+      getDiagramElement()?.remove();
       el.appendChild(svgDom);
 
       // Inject bg pattern for deprecated modules
@@ -264,7 +265,9 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
 
   // Effect: Colorize nodes
   useEffect(() => {
-    colorizeGraph($<SVGSVGElement>('#graph svg')[0], colorize);
+    const svg = getDiagramElement();
+    if (!svg) return;
+    colorizeGraph(svg, colorize);
   }, [colorize, domSignal]);
 
   // (Re)apply zoom if/when it changes
@@ -412,4 +415,8 @@ function colorizeGraph(svg: SVGSVGElement, colorize: string) {
       }
     });
   }
+}
+
+export function getDiagramElement() {
+  return document.querySelector<SVGSVGElement>('#graph svg#graph-diagram');
 }

--- a/components/GraphDiagram/GraphDiagramDownloadButton.tsx
+++ b/components/GraphDiagram/GraphDiagramDownloadButton.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { report } from '../../lib/bugsnag.js';
 import $ from '../../lib/dom.js';
+import { DownloadIcon } from '../Icons.js';
+import { getDiagramElement } from './GraphDiagram.js';
 
 type DownloadExtension = 'svg' | 'png';
 
@@ -9,10 +11,9 @@ export default function GraphDiagramDownloadButton() {
     <button
       onClick={() => download('svg')}
       title="download as SVG"
-      className="material-icons"
       style={{ marginLeft: '0.5em' }}
     >
-      cloud_download
+      <DownloadIcon />
     </button>
   );
 }
@@ -29,7 +30,10 @@ function download(type: DownloadExtension) {
 }
 
 function downloadPng() {
-  const svg = $<SVGSVGElement>('#graph svg')[0];
+  const svg = getDiagramElement();
+
+  if (!svg) return;
+
   const data = svg.outerHTML;
   const vb = svg.getAttribute('viewBox')?.split(' ');
 
@@ -57,11 +61,14 @@ function downloadPng() {
 }
 
 function downloadSvg() {
+  const svg = getDiagramElement();
+  if (!svg) return;
+
   alert(
     'Note: SVG downloads use the "Roboto Condensed" font, available at https://fonts.google.com/specimen/Roboto+Condensed.',
   );
 
-  const svgData = $<SVGSVGElement>('#graph svg')[0].outerHTML;
+  const svgData = svg.outerHTML;
   const svgBlob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
   const svgUrl = URL.createObjectURL(svgBlob);
   generateLinkToDownload('svg', svgUrl);

--- a/components/GraphDiagram/GraphDiagramZoomButtons.tsx
+++ b/components/GraphDiagram/GraphDiagramZoomButtons.tsx
@@ -5,22 +5,24 @@ import {
   ZOOM_FIT_WIDTH,
   ZOOM_NONE,
 } from '../../lib/constants.js';
+import { cn } from '../../lib/dom.js';
 import useHashParam from '../../lib/useHashParam.js';
+import { ZoomHorizontalIcon, ZoomVerticalIcon } from '../Icons.js';
 
 export function GraphDiagramZoomButtons() {
   const [zoom, setZoom] = useHashParam(PARAM_ZOOM);
   return (
     <>
       <button
-        className={`material-icons ${zoom == ZOOM_FIT_WIDTH ? 'selected' : ''}`}
+        className={cn({ selected: zoom == ZOOM_FIT_WIDTH })}
         onClick={() => setZoom(ZOOM_FIT_WIDTH)}
         title="zoom (fit width)"
         style={{ borderRadius: '3px 0 0 3px' }}
       >
-        swap_horiz
+        <ZoomHorizontalIcon />
       </button>
       <button
-        className={zoom == ZOOM_NONE ? 'selected' : ''}
+        className={cn({ selected: zoom == ZOOM_NONE })}
         onClick={() => setZoom(ZOOM_NONE)}
         title="zoom (1:1)"
         style={{
@@ -34,14 +36,12 @@ export function GraphDiagramZoomButtons() {
         1:1
       </button>
       <button
-        className={`material-icons ${
-          zoom == ZOOM_FIT_HEIGHT ? 'selected' : ''
-        }`}
+        className={cn({ selected: zoom == ZOOM_FIT_HEIGHT })}
         onClick={() => setZoom(ZOOM_FIT_HEIGHT)}
         title="zoom (fit height)"
         style={{ borderRadius: '0 3px 3px 0' }}
       >
-        swap_vert
+        <ZoomVerticalIcon />
       </button>
     </>
   );

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,0 +1,98 @@
+import React, { HTMLProps } from 'react';
+
+// SVG icons.  To create a new icon, get the icon's SVG `path` and copy-paste it
+// here.  The path should fit w/in a 16x16 box (with a ~0.5px margin).  The paths provided by octicons work pretty well for this, but may need to be scaled.
+
+type IconProps = {
+  width?: number;
+  height?: number;
+} & HTMLProps<SVGSVGElement>;
+
+// General SVG-based icon component path.
+function Icon({
+  strokePath,
+  fillPath,
+  width = 16,
+  height = 16,
+  ...props
+}: {
+  strokePath?: string;
+  fillPath?: string;
+  width?: number;
+  height?: number;
+} & IconProps) {
+  return (
+    // Hack: Ran into an issue where the <svg> component doesn't get rendered
+    // unless it's wrapped in a <div>.  No idea why.
+    <div style={{ display: 'inline-block', verticalAlign: 'middle' }}>
+      <svg viewBox={`0 0 16 16`} width={width} height={height} {...props}>
+        {strokePath ? (
+          <path
+            d={fillPath}
+            style={{
+              fill: 'currentColor',
+              stroke: 'none',
+            }}
+          ></path>
+        ) : null}
+        {strokePath ? (
+          <path
+            d={strokePath}
+            style={{
+              stroke: 'currentColor',
+              strokeWidth: 1.5,
+              strokeLinecap: 'round',
+              strokeLinejoin: 'round',
+              fill: 'none',
+            }}
+          ></path>
+        ) : null}
+      </svg>
+    </div>
+  );
+}
+
+// Paths for these can be found in art/icons.svg
+
+export function GithubIcon() {
+  // Original path from https://primer.style/design/foundations/icons/mark-github-16
+  return (
+    <Icon fillPath="m 8,1 c 4,0 7.2,3.2 7.2,7.2 a 7.2,7.2 0 0 1 -4.9,6.8 c -0.4,0.1 -0.5,-0.1 -0.5,-0.3 0,-0.2 0,-1 0,-2 0,-0.7 -0.2,-1.1 -0.5,-1.3 1.6,-0.2 3.3,-0.8 3.3,-3.5 0,-0.8 -0.3,-1.4 -0.7,-1.9 0.1,-0.2 0.3,-0.9 -0.1,-1.9 0,0 -0.6,-0.2 -2,0.7 -0.6,-0.2 -1.2,-0.2 -1.8,-0.2 -0.6,0 -1.2,0.1 -1.8,0.2 -1.4,-0.9 -2,-0.7 -2,-0.7 -0.4,1 -0.1,1.7 -0.1,1.9 -0.5,0.5 -0.7,1.1 -0.7,1.9 0,2.7 1.7,3.4 3.3,3.5 -0.2,0.2 -0.4,0.5 -0.5,1 -0.4,0.2 -1.4,0.5 -2.1,-0.6 -0.1,-0.2 -0.5,-0.7 -1.1,-0.7 -0.6,0 -0.2,0.3 0,0.5 0.3,0.2 0.7,0.8 0.7,1 0.1,0.4 0.6,1.2 2.4,0.8 0,0.6 0,1.2 0,1.3 0,0.2 -0.1,0.4 -0.5,0.3 A 7.2,7.2 0 0 1 0.8,8.2 c 0,-4 3.2,-7.2 7.2,-7.2 z" />
+  );
+}
+
+export function ZoomHorizontalIcon(props: IconProps) {
+  return (
+    <Icon
+      strokePath="M 13,8 H 3 M 5,5 3,8 5,11 m 6,-6 2,3 -2,3 M 4,1 H 1 V 15 H 4 M 12,1 h 3 v 14 h -3"
+      {...props}
+    />
+  );
+}
+
+export function ZoomVerticalIcon(props: IconProps) {
+  return (
+    <Icon
+      strokePath="m 8,3 v 10 m -3,-2 3,2 3,-2 M 5,5 8,3 11,5 M 1,12 v 3 H 15 V 12 M 1,4 V 1 h 14 v 3"
+      {...props}
+    />
+  );
+}
+
+export function DownloadIcon(props: IconProps) {
+  return (
+    <Icon
+      strokePath="m 10,11 c 0,0 -0,3 2,4 H 4 c 2,-1 2,-4 2,-4 m 5,-9 h 4 v 9 H 1 V 2 H 5 M 10,6 8,8 6,6 M 8,1 v 7"
+      {...props}
+    />
+  );
+}
+
+export function OffsiteLinkIcon(props: IconProps) {
+  return (
+    <Icon
+      strokePath="m 13,7 v 7 H 2 V 3 h 7 m 2,-2 h 4 v 4 z m 2,2 -5,5"
+      {...props}
+    />
+  );
+}

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -104,7 +104,7 @@ export default function ModulePane({
 
       {/* For NPM packages */}
       {!module.package._local ? (
-        <>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <ExternalLink href={module.packageJsonLink}>
             package.json
           </ExternalLink>
@@ -116,7 +116,7 @@ export default function ModulePane({
               GitHub
             </ExternalLink>
           ) : null}
-        </>
+        </div>
       ) : null}
 
       <Section title="Bundle Size">

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -4,7 +4,6 @@ export function Section({
   title,
   children,
   open = true,
-
   ...props
 }: { title: string; open?: boolean } & HTMLProps<HTMLDetailsElement>) {
   return (

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <link
-      href="https://fonts.googleapis.com/css?family=Roboto+Condensed|Material+Icons"
+      href="https://fonts.googleapis.com/css?family=Roboto+Condensed"
       rel="stylesheet"
     />
     <link href="./index.scss" rel="stylesheet" />

--- a/index.scss
+++ b/index.scss
@@ -88,7 +88,3 @@ h2 {
   border-radius: var(--rad_sm);
   font-size: 14pt;
 }
-
-.material-icons {
-  font-size: inherit;
-}

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -1,9 +1,6 @@
 import { PackumentVersion } from '@npm/types';
 
 export interface ModulePackage extends PackumentVersion {
-  // TODO: This needs to be fixed in @npm/types
-  deprecated?: boolean;
-
   _stub?: boolean;
   _local?: boolean;
   _stubError?: Error;


### PR DESCRIPTION
Needed a icon for a github link in my other branch, which doesn't exist in the "material" icon set.  And, also, the horz. and vert. zoom icons have bugged me for *years*... so I'm switching to an SVG-based "Icon" component of my own creation that's a bit more versatile.

This provides a not-terrible way of incorporating icons from other SVG icon suites (copy/paste the SVG into Inkscape and massage to fit), and of making custom icons.

This removes the Material font dependency (128KB)... not that it matters.   That font is almost certainly in most users' browser cache.
