### PR TITLE
feat: last-modified date colorizer

### DIFF
--- a/components/GraphPane/colorizers/ModifiedDateColorizer.tsx
+++ b/components/GraphPane/colorizers/ModifiedDateColorizer.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Module from '../../../lib/Module.js';
+import { getModifiedDate } from '../../../lib/ModuleCache.js';
+import { COLORIZE_COLORS } from '../../../lib/constants.js';
+import { SimpleColorizer } from './index.js';
+
+export default {
+  title: 'Last Modified Date',
+  name: 'modified',
+
+  legend() {
+    return (
+      <>
+        <span style={{ fontWeight: 'bold', color: COLORIZE_COLORS[3] }}>
+          {'\u2B24'}
+        </span>{' '}
+        &lt; 1 month,
+        <span style={{ color: COLORIZE_COLORS[2] }}>{'\u2B24'}</span> &lt; 6
+        months,
+        <span style={{ color: COLORIZE_COLORS[1] }}>{'\u2B24'}</span> &lt; 2
+        years,
+        <span style={{ color: COLORIZE_COLORS[0] }}>{'\u2B24'}</span> &ge; 2
+        years
+      </>
+    );
+  },
+
+  async colorForModule(module: Module) {
+    let date;
+    try {
+      date = await getModifiedDate(module.name);
+    } catch {
+      return '';
+    }
+
+    if (!date) return '';
+    const age = Date.now() - date.getTime();
+    if (age < 1000 * 60 * 60 * 24 * 30) return COLORIZE_COLORS[3];
+    if (age < 1000 * 60 * 60 * 24 * 30 * 6) return COLORIZE_COLORS[2];
+    if (age < 1000 * 60 * 60 * 24 * 365 * 2) return COLORIZE_COLORS[1];
+    return COLORIZE_COLORS[0];
+  },
+} as SimpleColorizer;

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -7,7 +7,7 @@ export const COLORIZE_MODULE_CJS = 'var(--bg-orange)';
 export const COLORIZE_MODULE_ESM = 'var(--bg-blue)';
 
 export default {
-  title: 'Module type',
+  title: 'Module Type',
   name: 'moduleType',
 
   legend() {
@@ -21,8 +21,10 @@ export default {
 
   colorForModule(module: Module) {
     const url = `https://cdn.jsdelivr.net/npm/${module.key}/package.json`;
-    return fetchJSON<{ type: string }>(url).then(pkg =>
-      pkg.type === 'module' ? COLORIZE_MODULE_ESM : COLORIZE_MODULE_CJS,
-    );
+    return fetchJSON<{ type: string }>(url)
+      .then(pkg =>
+        pkg.type === 'module' ? COLORIZE_MODULE_ESM : COLORIZE_MODULE_CJS,
+      )
+      .catch(() => '');
   },
 } as SimpleColorizer;

--- a/components/GraphPane/colorizers/index.ts
+++ b/components/GraphPane/colorizers/index.ts
@@ -1,5 +1,6 @@
 import Module from '../../../lib/Module.js';
 import BusFactorColorizer from './BusFactorColorizer.js';
+import ModifiedDateColorizer from './ModifiedDateColorizer.js';
 import ModuleTypeColorizer from './ModuleTypeColorizer.js';
 import {
   NPMSMaintenanceColorizer,
@@ -25,6 +26,7 @@ export interface BulkColorizer extends Colorizer {
 const colorizers: (SimpleColorizer | BulkColorizer)[] = [
   ModuleTypeColorizer,
   BusFactorColorizer,
+  ModifiedDateColorizer,
   NPMSOverallColorizer,
   NPMSQualityColorizer,
   NPMSPopularityColorizer,

--- a/index.scss
+++ b/index.scss
@@ -55,7 +55,8 @@
     --bg1: #696666;
     --bg2: #333;
 
-    --bg-L: 40%; // Background intensity (dark)
+    --bg-L: 30%; // Background intensity
+    --bg-S: 100%; // Background saturation
     --bg-dark-L: 40%; // Background intensity (dark)
 
     --highlight: #ff761a;

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -15,7 +15,7 @@ export default class Module {
   package: ModulePackage;
 
   static key(name: string, version?: string) {
-    if (/^https?:\/\//.test(name)) {
+    if (this.isHttpModule(name)) {
       if (version) throw new Error(`URL-based module should not have version`);
       return name;
     }
@@ -39,6 +39,10 @@ export default class Module {
       _stub: true,
       _stubError: error,
     } as unknown as ModulePackage);
+  }
+
+  static isHttpModule(moduleKey: string) {
+    return /^https?:\/\//.test(moduleKey);
   }
 
   // TODO: This should take either ModulePackage or PackageJSON... but need to


### PR DESCRIPTION
Adds ability to colorize by "last modified date".

Example: https://npmgraph-git-datecolorizer-npmgraph.vercel.app/?q=express#color=modified

I'm a little unsure whether to merge this.   The "Last modified date" is last time [the package record was modified in the NPM registry](https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-metadata-format).  That'll generally be the date of the last version that was published, but could also be something unrelated (e.g. when a version was unpublished, or an owner changed or... whatever.)  I'm concerned this could be more confusing or misleading than actually helpful.

Thoughts?