### PR TITLE
feat: selection shows full up/downstream dependencies (fixes #144, fixes #72)

### DIFF
--- a/components/GraphDiagram/GraphDiagram.scss
+++ b/components/GraphDiagram/GraphDiagram.scss
@@ -86,9 +86,27 @@ g.node {
     opacity: 0.5;
   }
 
-  &.selected > path {
-    stroke-width: 3;
-    stroke: var(--highlight);
+  &.selected {
+    & > path {
+      stroke-width: 3;
+      stroke: var(--highlight);
+    }
+  }
+
+  &.upstream {
+    & > path {
+      stroke: var(--bg-blue);
+    }
+  }
+
+  &.downstream {
+    & > path {
+      stroke: var(--bg-orange);
+    }
+  }
+
+  &.unselected {
+    opacity: 0.35;
   }
 
   &.warning > path {
@@ -111,14 +129,30 @@ g.edge {
     fill: var(--text);
   }
 
-  &.selected > path {
-    stroke-width: 3;
-    stroke: var(--highlight);
+  &.upstream {
+    & > path {
+      stroke: var(--bg-blue);
+    }
+
+    & > polygon {
+      stroke: var(--bg-blue);
+      fill: var(--bg-blue);
+    }
   }
 
-  &.selected > polygon {
-    stroke: var(--highlight);
-    fill: var(--highlight);
+  &.downstream {
+    & > path {
+      stroke: var(--bg-orange);
+    }
+
+    & > polygon {
+      stroke: var(--bg-orange);
+      fill: var(--bg-orange);
+    }
+  }
+
+  &.unselected {
+    opacity: 0.35;
   }
 }
 

--- a/components/Icons.scss
+++ b/components/Icons.scss
@@ -18,7 +18,10 @@
   stroke: var(--bg-violet);
 }
 
-a .icon,
-button .icon {
+a .icon {
   vertical-align: middle;
+}
+
+button .icon {
+  vertical-align: baseline;
 }

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -123,6 +123,7 @@ async function getModuleFromNPM(
   return new Module(pkg);
 }
 
+// Note: getModule() should never throw. Instead, it should return a stub module
 export async function getModule(moduleKey: string): Promise<Module> {
   if (!moduleKey) throw Error('Undefined module name');
 


### PR DESCRIPTION
Changes selection in the graph diagram as follows:
* Selected module highlighted in orange (as before)
* All downstream dependencies highlighted in orange (not just immediate dependencies)
* All upstream dependencies highlighted in blue
* Any edges or nodes outside of the selected modules' dependency graph are dimmed (opacity=0.35)

@fregante Any feedback you have on behavior or styling would be great.   I've been wanting to implement this selection behavior for a long time, as it feels a lot more intuitive to me so I'm hoping you think it's an improvement. :-)

![CleanShot 2023-10-12 at 11 20 21@2x](https://github.com/npmgraph/npmgraph/assets/164050/0510aa84-ba6c-4616-8e31-3fafe4553b81)
