### PR TITLE
feat: store collapse state in URL hash

### DIFF
--- a/components/App/App.tsx
+++ b/components/App/App.tsx
@@ -12,7 +12,6 @@ import { Loader } from './Loader.js';
 
 export const [usePane] = sharedStateHook('info', 'pane');
 export const [useGraph] = sharedStateHook(null as GraphState | null, 'graph');
-export const [useExcludes] = sharedStateHook([] as string[], 'excludes');
 
 export default function App() {
   const activity = useActivity();

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -20,10 +20,11 @@ import {
 } from '../../lib/constants.js';
 import { createAbortable } from '../../lib/createAbortable.js';
 import $ from '../../lib/dom.js';
+import useCollapse from '../../lib/useCollapse.js';
 import useGraphSelection from '../../lib/useGraphSelection.js';
 import useHashParam from '../../lib/useHashParam.js';
 import { useQuery } from '../../lib/useQuery.js';
-import { useExcludes, useGraph, usePane } from '../App/App.js';
+import { useGraph, usePane } from '../App/App.js';
 import {
   getColorizer,
   isSimpleColorizer,
@@ -53,7 +54,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
   const [, setZenMode] = useHashParam(PARAM_VIEW_MODE);
   const [queryType, queryValue, setGraphSelection] = useGraphSelection();
   const [graph, setGraph] = useGraph();
-  const [excludes, setExcludes] = useExcludes();
+  const [collapse, setCollapse] = useCollapse();
   const [colorize] = useHashParam(PARAM_COLORIZE);
   const [zoom] = useHashParam(PARAM_ZOOM);
 
@@ -83,11 +84,12 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
     // Toggle exclude filter?
     if (el && event.shiftKey) {
       if (module) {
-        const isIncluded = excludes.includes(module.name);
+        const isIncluded = collapse.includes(module.name);
         if (isIncluded) {
-          setExcludes(excludes.filter(n => n !== module.name));
+          setCollapse(collapse.filter(n => n !== module.name));
         } else {
-          setExcludes([...excludes, module.name]);
+          console.log('fdsjafdsj');
+          setCollapse([...collapse, module.name]);
         }
       }
 
@@ -138,7 +140,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
 
   // Filter for which modules should be shown / collapsed in the graph
   function moduleFilter({ name }: { name: string }) {
-    return !excludes?.includes(name);
+    return !collapse?.includes(name);
   }
 
   // NOTE: Graph rendering can take a significant amount of time.  It is also dependent on UI settings.
@@ -155,7 +157,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
     });
 
     return abort;
-  }, [[...query].sort().join(), [...dependencyTypes].join(), excludes]);
+  }, [[...query].sort().join(), [...dependencyTypes].join(), collapse]);
 
   // Effect: Insert SVG markup into DOM
   useEffect(() => {

--- a/components/GraphPane/GraphPane.tsx
+++ b/components/GraphPane/GraphPane.tsx
@@ -2,10 +2,10 @@ import { Maintainer } from '@npm/types';
 import React from 'react';
 import simplur from 'simplur';
 import useHashParam from '../../lib/useHashParam.js';
-import { useExcludes } from '../App/App.js';
 
 import { PARAM_DEPENDENCIES } from '../../lib/constants.js';
 import { isDefined } from '../../lib/guards.js';
+import useCollapse from '../../lib/useCollapse.js';
 import { DependencyKey, GraphState } from '../GraphDiagram/graph_util.js';
 import { Pane } from '../Pane.js';
 import { PieGraph } from '../PieGraph.js';
@@ -22,7 +22,7 @@ export default function GraphPane({
 }: { graph: GraphState | null } & React.HTMLAttributes<HTMLDivElement>) {
   const compareEntryKey = ([a]: [string, unknown], [b]: [string, unknown]) =>
     a < b ? -1 : a > b ? 1 : 0;
-  const [excludes] = useExcludes();
+  const [collapse, setCollapse] = useCollapse();
   const [depTypes, setDepTypes] = useHashParam(PARAM_DEPENDENCIES);
 
   const dependencyTypes = (depTypes.split(/\s*,\s*/) as DependencyKey[]).filter(
@@ -86,7 +86,7 @@ export default function GraphPane({
                 type="name"
                 value={value}
                 count={count}
-                className={excludes.includes(value) ? 'collapsed' : ''}
+                className={collapse.includes(value) ? 'collapsed' : ''}
               />
             ))}
         </Tags>
@@ -98,7 +98,14 @@ export default function GraphPane({
             marginTop: '1em',
           }}
         >
-          (Shift-click modules in graph to expand/collapse)
+          {collapse.length ? (
+            <span>
+              {simplur`${collapse.length} module[|s] collapsed `}
+              <button onClick={() => setCollapse([])}>Expand All</button>
+            </span>
+          ) : (
+            <span>(Shift-click modules in graph to expand/collapse)</span>
+          )}
         </div>
       </Section>
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,6 +8,7 @@ export const COLORIZE_COLORS = [
 
 export const PARAM_COLORIZE = 'color';
 export const PARAM_DEPENDENCIES = 'deps';
+export const PARAM_COLLAPSE = 'collapse';
 export const PARAM_PACKAGES = 'packages';
 export const PARAM_QUERY = 'q';
 export const PARAM_SELECTION = 'select';

--- a/lib/useCollapse.ts
+++ b/lib/useCollapse.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { PARAM_COLLAPSE } from './constants.js';
+import useHashParam from './useHashParam.js';
+
+export default function useCollapse() {
+  const [val, setVal] = useHashParam(PARAM_COLLAPSE);
+  const excludes = useMemo(
+    () =>
+      val
+        .split(',')
+        .filter(Boolean)
+        .sort()
+        .map(v => v.trim()),
+    [val],
+  );
+
+  return [
+    excludes,
+    function (excludes: string[]) {
+      setVal(excludes.sort().join(','));
+    },
+  ] as const;
+}


### PR DESCRIPTION
Renames "excludes" to "collapse" in all the places.  Also keep `collapse` state in URL hash rather than in-memory, since it's part of the view configuration.