### PR TITLE
feat: colorize by "outdated" level, fix #138

### DIFF
--- a/components/GraphPane/colorizers/BusFactorColorizer.tsx
+++ b/components/GraphPane/colorizers/BusFactorColorizer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Module from '../../../lib/Module.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
+import { LegendColor } from './LegendColor.js';
 import { SimpleColorizer } from './index.js';
 
 export default {
@@ -10,14 +11,10 @@ export default {
   legend() {
     return (
       <>
-        <span style={{ fontWeight: 'bold', color: COLORIZE_COLORS[0] }}>
-          {'\u2B24'}
-        </span>{' '}
-        = 1 maintainer,
-        <span style={{ color: COLORIZE_COLORS[1] }}>{'\u2B24'}</span> = 2,
-        <span style={{ color: COLORIZE_COLORS[2] }}>{'\u2B24'}</span> = 3,
-        <span style={{ color: COLORIZE_COLORS[3] }}>{'\u2B24'}</span> = 4 or
-        more
+        <LegendColor color="0">1 Maintainer</LegendColor>
+        <LegendColor color="1">2 Maintainers</LegendColor>
+        <LegendColor color="2">3 Maintainers</LegendColor>
+        <LegendColor color="3">4+ Maintainers</LegendColor>
       </>
     );
   },

--- a/components/GraphPane/colorizers/LegendColor.tsx
+++ b/components/GraphPane/colorizers/LegendColor.tsx
@@ -1,0 +1,17 @@
+import React, { HTMLProps } from 'react';
+import { COLORIZE_COLORS } from '../../../lib/constants.js';
+
+export function LegendColor({
+  color,
+  children,
+  ...props
+}: HTMLProps<HTMLDivElement>) {
+  color = COLORIZE_COLORS[Number(color)] ?? color;
+
+  return (
+    <div {...props} style={{ margin: '.3rem 0' }}>
+      <span style={{ color, marginRight: '0.5rem' }}>{'\u2B24'}</span>
+      {children}
+    </div>
+  );
+}

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -1,28 +1,31 @@
 import React from 'react';
 import Module from '../../../lib/Module.js';
 import fetchJSON from '../../../lib/fetchJSON.js';
+import { LegendColor } from './LegendColor.js';
 import { SimpleColorizer } from './index.js';
 
 export const COLORIZE_MODULE_CJS = 'var(--bg-orange)';
 export const COLORIZE_MODULE_ESM = 'var(--bg-blue)';
 
 export default {
-  title: 'Module type',
+  title: 'Module Type',
   name: 'moduleType',
 
   legend() {
     return (
       <>
-        <span style={{ color: COLORIZE_MODULE_CJS }}>{'\u2B24'}</span> = CJS,
-        <span style={{ color: COLORIZE_MODULE_ESM }}>{'\u2B24'}</span> = ESM,
+        <LegendColor color={COLORIZE_MODULE_CJS}>CommonJS (CJS)</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_ESM}>EcmaScript (ESM)</LegendColor>
       </>
     );
   },
 
   colorForModule(module: Module) {
     const url = `https://cdn.jsdelivr.net/npm/${module.key}/package.json`;
-    return fetchJSON<{ type: string }>(url).then(pkg =>
-      pkg.type === 'module' ? COLORIZE_MODULE_ESM : COLORIZE_MODULE_CJS,
-    );
+    return fetchJSON<{ type: string }>(url)
+      .then(pkg =>
+        pkg.type === 'module' ? COLORIZE_MODULE_ESM : COLORIZE_MODULE_CJS,
+      )
+      .catch(() => '');
   },
 } as SimpleColorizer;

--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -110,7 +110,7 @@ class NPMSColorizer implements BulkColorizer {
 }
 
 export const NPMSOverallColorizer = new NPMSColorizer(
-  'NPMS.io Score (Overall)',
+  'NPMS.io Score',
   COLORIZE_OVERALL,
 );
 export const NPMSPopularityColorizer = new NPMSColorizer(

--- a/components/GraphPane/colorizers/OutdatedColorizer.tsx
+++ b/components/GraphPane/colorizers/OutdatedColorizer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { diff } from 'semver';
+import Module from '../../../lib/Module.js';
+import { getNPMManifest } from '../../../lib/ModuleCache.js';
+import { COLORIZE_COLORS } from '../../../lib/constants.js';
+import { LegendColor } from './LegendColor.js';
+import { SimpleColorizer } from './index.js';
+
+export default {
+  title: 'Outdated Level',
+  name: 'outdated',
+
+  legend() {
+    return (
+      <>
+        <LegendColor color="3">Module is up to date</LegendColor>
+        <LegendColor color="2">PATCH updates available</LegendColor>
+        <LegendColor color="1">MINOR updates available</LegendColor>
+        <LegendColor color="0">MAJOR updates available</LegendColor>
+      </>
+    );
+  },
+
+  async colorForModule(module: Module) {
+    const manifest = await getNPMManifest(module.name);
+
+    const latestVersion = manifest?.['dist-tags']?.latest ?? '';
+
+    let outdated;
+    try {
+      outdated = diff(module.version, latestVersion);
+    } catch (err) {
+      console.error(err);
+      return '';
+    }
+    console.log(module.key, module.version, latestVersion, outdated);
+    switch (outdated) {
+      case 'major':
+        return COLORIZE_COLORS[0];
+      case 'minor':
+        return COLORIZE_COLORS[1];
+      case 'patch':
+        return COLORIZE_COLORS[2];
+      case null:
+        return COLORIZE_COLORS[3];
+      default:
+        return '';
+    }
+  },
+} as SimpleColorizer;

--- a/components/GraphPane/colorizers/index.ts
+++ b/components/GraphPane/colorizers/index.ts
@@ -1,12 +1,8 @@
 import Module from '../../../lib/Module.js';
 import BusFactorColorizer from './BusFactorColorizer.js';
 import ModuleTypeColorizer from './ModuleTypeColorizer.js';
-import {
-  NPMSMaintenanceColorizer,
-  NPMSOverallColorizer,
-  NPMSPopularityColorizer,
-  NPMSQualityColorizer,
-} from './NPMSColorizer.js';
+import { NPMSOverallColorizer } from './NPMSColorizer.js';
+import OutdatedColorizer from './OutdatedColorizer.js';
 
 interface Colorizer {
   title: string;
@@ -25,10 +21,8 @@ export interface BulkColorizer extends Colorizer {
 const colorizers: (SimpleColorizer | BulkColorizer)[] = [
   ModuleTypeColorizer,
   BusFactorColorizer,
+  OutdatedColorizer,
   NPMSOverallColorizer,
-  NPMSQualityColorizer,
-  NPMSPopularityColorizer,
-  NPMSMaintenanceColorizer,
 ];
 
 export function isSimpleColorizer(

--- a/index.scss
+++ b/index.scss
@@ -55,7 +55,8 @@
     --bg1: #696666;
     --bg2: #333;
 
-    --bg-L: 40%; // Background intensity (dark)
+    --bg-L: 30%; // Background intensity
+    --bg-S: 100%; // Background saturation
     --bg-dark-L: 40%; // Background intensity (dark)
 
     --highlight: #ff761a;

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -15,7 +15,7 @@ export default class Module {
   package: ModulePackage;
 
   static key(name: string, version?: string) {
-    if (/^https?:\/\//.test(name)) {
+    if (this.isHttpModule(name)) {
       if (version) throw new Error(`URL-based module should not have version`);
       return name;
     }
@@ -41,9 +41,14 @@ export default class Module {
     } as unknown as ModulePackage);
   }
 
+  static isHttpModule(moduleKey: string) {
+    return /^https?:\/\//.test(moduleKey);
+  }
+
   // TODO: This should take either ModulePackage or PackageJSON... but need to
   // be clear about the differences between the two!
   constructor(pkg: ModulePackage) {
+    console.log('Module', pkg.name, pkg.version, pkg.npmVersion);
     if (!pkg.name) {
       throw new Error(`Package name is required`);
     }


### PR DESCRIPTION
Adds an "Outdated Level" colorizer that colors modules by how out of date they are.

Note: There's no UI currently for showing what the latest version is, but that seems like a pretty obvious and simple addition.  I'll open a new issue for that.

![CleanShot 2023-10-15 at 15 11 41@2x](https://github.com/npmgraph/npmgraph/assets/164050/5b74b2cc-46f1-4c28-b06c-de73177a7ad7)
