### PR TITLE
fix: don't let fetch() requests interfere with UI

### DIFF
--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -57,6 +57,8 @@ class NPMSColorizer implements BulkColorizer {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(namesInRequest),
+            silent: true,
+            timeout: 5000,
           },
         ),
       );

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -37,12 +37,14 @@ export default function ModulePane({
 
     fetchJSON<BundlePhobiaData>(
       `https://bundlephobia.com/api/size?package=${pn}`,
+      { silent: true, timeout: 5000 },
     )
       .then(data => setBundleInfo(data))
       .catch(err => setBundleInfo(err));
 
     fetchJSON<NPMSIOData>(
       `https://api.npms.io/v2/package/${encodeURIComponent(pkg.name)}`,
+      { silent: true, timeout: 5000 },
     )
       .then(data => setNpmsData(data))
       .catch(err => setNpmsData(err));
@@ -128,7 +130,7 @@ export default function ModulePane({
         {!bundleInfo ? (
           'Loading ...'
         ) : bundleInfo instanceof Error ? (
-          'Unavailable'
+          'Bundle size not currently available'
         ) : (
           <>
             <ModuleBundleStats bundleInfo={bundleInfo} />
@@ -143,9 +145,9 @@ export default function ModulePane({
 
       <Section title="npms.io Score">
         {!npmsData ? (
-          'Loading'
+          'Loading ...'
         ) : npmsData instanceof Error ? (
-          'Unavailable'
+          'Score not currently available'
         ) : (
           <ModuleNpmsIOScores scores={npmsData.score} />
         )}

--- a/lib/fetchJSON.ts
+++ b/lib/fetchJSON.ts
@@ -9,7 +9,7 @@ export function setActivityForRequestCache(act: LoadActivity) {
 }
 export default function fetchJSON<T>(
   input: RequestInfo | URL,
-  init?: RequestInit & { silent?: boolean },
+  init?: RequestInit & { silent?: boolean; timeout?: number },
 ): Promise<T> {
   const url = typeof input === 'string' ? input : input.toString();
   const cacheKey = `${url} ${JSON.stringify(init)}`;
@@ -18,9 +18,17 @@ export default function fetchJSON<T>(
     return requestCache.get(cacheKey) as Promise<T>;
   }
 
+  init ??= {};
+
+  if (init.timeout) {
+    if (init.signal) throw new Error('Cannot use timeout with signal');
+    // Abort request after `timeout`, while also respecting user-supplied `signal`
+    init.signal = AbortSignal.timeout(init.timeout);
+  }
+
   const traceError = new Error();
 
-  const finish = init?.silent
+  const finish = init.silent
     ? () => {}
     : activity?.start(`Fetching ${decodeURIComponent(url)}`);
 

--- a/lib/useCommits.ts
+++ b/lib/useCommits.ts
@@ -12,7 +12,7 @@ export async function fetchCommits() {
   try {
     let commits = await fetchJSON<GithubCommit[]>(
       `https://api.github.com/repos/npmgraph/npmgraph/commits?since=${since.toISOString()}`,
-      { silent: true },
+      { silent: true, timeout: 5000 },
     );
 
     // Walk commits and tag commits we want to expose with the


### PR DESCRIPTION
Adds support for  a `timeout` on fetchJSON() requests, and also makes non-essential requests (e.g. npms.io, bundlephobia, github commits list) "silent" so they don't trigger the Activity component (which tends to interfere with the tab bar.)