### PR TITLE
feat: display module version outdated-ness, closes #175

### DIFF
--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -1,7 +1,9 @@
 import React, { HTMLProps } from 'react';
 import { queryModuleCache } from '../lib/ModuleCache.js';
+import { PARAM_VIEW_MODE, VIEW_MODE_CLOSED } from '../lib/constants.js';
 import useCommits from '../lib/useCommits.js';
 import useGraphSelection from '../lib/useGraphSelection.js';
+import useHashParam from '../lib/useHashParam.js';
 import { version as VERSION } from '../package.json';
 import AboutPane from './AboutPane/AboutPane.js';
 import { useGraph, usePane } from './App/App.js';
@@ -10,10 +12,8 @@ import GraphPane from './GraphPane/GraphPane.js';
 import InfoPane from './InfoPane/InfoPane.js';
 import './Inspector.scss';
 import ModulePane from './ModulePane/ModulePane.js';
-import { Tab } from './Tab.js';
 import { Splitter } from './Splitter.js';
-import { PARAM_VIEW_MODE, VIEW_MODE_CLOSED } from '../lib/constants.js';
-import useHashParam from '../lib/useHashParam.js';
+import { Tab } from './Tab.js';
 
 export default function Inspector(props: HTMLProps<HTMLDivElement>) {
   const [pane, setPane] = usePane();
@@ -25,12 +25,13 @@ export default function Inspector(props: HTMLProps<HTMLDivElement>) {
   const isOpen = viewMode != VIEW_MODE_CLOSED;
 
   const selectedModules = queryModuleCache(queryType, queryValue);
-  const firstModule = selectedModules.values().next().value;
 
   let paneComponent;
   switch (pane) {
     case 'module':
-      paneComponent = <ModulePane id="pane-module" module={firstModule} />;
+      paneComponent = (
+        <ModulePane id="pane-module" selectedModules={selectedModules} />
+      );
       break;
     case 'graph':
       paneComponent = <GraphPane id="pane-graph" graph={graph} />;

--- a/components/ModulePane/ModuleBundleSize.tsx
+++ b/components/ModulePane/ModuleBundleSize.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import Module from '../../lib/Module.js';
+import fetchJSON from '../../lib/fetchJSON.js';
+import { BundlePhobiaData } from '../../lib/fetch_types.js';
+import { ExternalLink } from '../ExternalLink.js';
+import { ModuleBundleStats } from './ModuleBundleStats.js';
+import './ModulePane.scss';
+import { ModuleTreeMap } from './ModuleTreeMap.js';
+
+export default function ModuleBundleSize({ module }: { module: Module }) {
+  const pkg = module.package;
+
+  const [bundleInfo, setBundleInfo] = useState<BundlePhobiaData | Error>();
+
+  const pn = encodeURIComponent(`${pkg.name}@${pkg.version}`);
+  const bpUrl = `https://bundlephobia.com/result?p=${pn}`;
+  const bpApiUrl = `https://bundlephobia.com/api/size?package=${pn}`;
+  const isLocalModule = Boolean(pkg._local);
+
+  useEffect(() => {
+    if (isLocalModule) return;
+
+    setBundleInfo(undefined);
+
+    if (!pkg) return;
+
+    fetchJSON<BundlePhobiaData>(bpApiUrl, { silent: true, timeout: 5000 })
+      .then(data => setBundleInfo(data))
+      .catch(err => setBundleInfo(err));
+  }, [pkg]);
+
+  return (
+    <>
+      {!bundleInfo ? (
+        'Loading ...'
+      ) : bundleInfo instanceof Error ? (
+        'Bundle size not currently available'
+      ) : (
+        <>
+          <ModuleBundleStats bundleInfo={bundleInfo} />
+          <ModuleTreeMap
+            style={{ height: '150px', margin: '1em' }}
+            data={bundleInfo}
+          />
+          Data source: <ExternalLink href={bpUrl}>BundlePhobia</ExternalLink>
+        </>
+      )}
+    </>
+  );
+}

--- a/components/ModulePane/ModuleNpmsIOScores.tsx
+++ b/components/ModulePane/ModuleNpmsIOScores.tsx
@@ -1,12 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import Module from '../../lib/Module.js';
+import fetchJSON from '../../lib/fetchJSON.js';
 import { NPMSIOData } from '../../lib/fetch_types.js';
 import { ModuleScoreBar } from './ModuleScoreBar.js';
 
-export function ModuleNpmsIOScores({
-  scores,
-}: {
-  scores: NPMSIOData['score'];
-}) {
+export default function ModuleNpmsIOScores({ module }: { module: Module }) {
+  const [npmsData, setNpmsData] = useState<NPMSIOData | Error>();
+
+  const pkg = module?.package;
+  const isLocalModule = Boolean(pkg?._local);
+
+  useEffect(() => {
+    if (isLocalModule) return;
+
+    setNpmsData(undefined);
+
+    if (!pkg) return;
+
+    fetchJSON<NPMSIOData>(
+      `https://api.npms.io/v2/package/${encodeURIComponent(pkg.name)}`,
+      { silent: true, timeout: 5000 },
+    )
+      .then(data => setNpmsData(data))
+      .catch(err => setNpmsData(err));
+  }, [pkg]);
+
+  if (!npmsData) {
+    return 'Loading ...';
+  } else if (npmsData instanceof Error) {
+    return 'Score not currently available';
+  }
+
+  const scores: NPMSIOData['score'] = npmsData.score;
+
   return (
     <div
       style={{

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import simplur from 'simplur';
 import Module from '../../lib/Module.js';
+import { PARAM_COLORIZE } from '../../lib/constants.js';
+import useHashParam from '../../lib/useHashParam.js';
 import { ExternalLink } from '../ExternalLink.js';
+import OutdatedColorizer from '../GraphPane/colorizers/OutdatedColorizer.js';
 import { GithubIcon } from '../Icons.js';
 import { Pane } from '../Pane.js';
 import { QueryLink } from '../QueryLink.js';
@@ -11,6 +14,7 @@ import { Tags } from '../Tags.js';
 import ModuleBundleSize from './ModuleBundleSize.js';
 import ModuleNpmsIOScores from './ModuleNpmsIOScores.js';
 import './ModulePane.scss';
+import { ModuleVersionInfo } from './ModuleVersionInfo.js';
 
 export default function ModulePane({
   selectedModules,
@@ -18,6 +22,7 @@ export default function ModulePane({
 }: {
   selectedModules?: Map<string, Module>;
 } & React.HTMLAttributes<HTMLDivElement>) {
+  const [colorize] = useHashParam(PARAM_COLORIZE);
   const nSelected = selectedModules?.size ?? 0;
   if (nSelected == 0) {
     return (
@@ -70,9 +75,29 @@ export default function ModulePane({
 
   return (
     <Pane {...props}>
-      <h2>
-        <QueryLink query={module.key} />
-      </h2>
+      <div
+        style={{
+          display: 'flex',
+          padding: '0.5rem 0',
+          gap: '1rem',
+          flexWrap: 'wrap',
+          alignItems: 'baseline',
+        }}
+      >
+        <h2
+          style={{
+            flexGrow: 0,
+            whiteSpace: 'nowrap',
+            margin: 0,
+          }}
+        >
+          <QueryLink query={module.key} />
+        </h2>
+
+        {colorize === OutdatedColorizer.name ? (
+          <ModuleVersionInfo module={module} style={{ flexGrow: 1 }} />
+        ) : null}
+      </div>
 
       {pkg.deprecated ? (
         <div

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -94,7 +94,7 @@ export default function ModulePane({
           <QueryLink query={module.key} />
         </h2>
 
-        {colorize === OutdatedColorizer.name ? (
+        {!colorize || colorize === OutdatedColorizer.name ? (
           <ModuleVersionInfo module={module} style={{ flexGrow: 1 }} />
         ) : null}
       </div>

--- a/components/ModulePane/ModuleVersionInfo.scss
+++ b/components/ModulePane/ModuleVersionInfo.scss
@@ -1,0 +1,22 @@
+#module-version {
+  border: solid 1px;
+  border-radius: 0.3rem;
+  padding: 0.1rem 0;
+  font-size: 0.85rem;
+  text-align: center;
+
+  &.dist-tag {
+    border: none;
+    text-align: inherit;
+  }
+
+  &.major-updates {
+    border-color: var(--stroke-red);
+  }
+  &.minor-updates {
+    border-color: var(--stroke-orange);
+  }
+  &.patch-updates {
+    border-color: var(--stroke-yellow);
+  }
+}

--- a/components/ModulePane/ModuleVersionInfo.tsx
+++ b/components/ModulePane/ModuleVersionInfo.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { parse } from 'semver';
+import simplur from 'simplur';
+import Module from '../../lib/Module.js';
+
+import { cn } from '../../lib/dom.js';
+import './ModuleVersionInfo.scss';
+
+export function ModuleVersionInfo({
+  module,
+  ...props
+}: { module: Module } & React.HTMLAttributes<HTMLDivElement>) {
+  if (!module.packument) {
+    return null;
+  }
+
+  const versionParts = parse(module.version);
+  if (!versionParts) {
+    return null;
+  }
+
+  const latestVersion = module.packument['dist-tags'].latest;
+  const latestParts = parse(latestVersion);
+  if (!latestParts) {
+    return null;
+  }
+
+  const majorDiff = latestParts.major - versionParts.major;
+  const minorDiff = latestParts.minor - versionParts.minor;
+  const patchDiff = latestParts.patch - versionParts.patch;
+
+  let distTag;
+  if (module.packument) {
+    for (const [tag, version] of Object.entries(
+      module.packument['dist-tags'],
+    )) {
+      if (version === module.version) {
+        distTag = tag;
+        break;
+      }
+    }
+  }
+
+  let content = null;
+  let className = '';
+  if (distTag) {
+    className = 'dist-tag';
+    content = (
+      <>
+        (<code>{distTag}</code>)
+      </>
+    );
+  } else if (majorDiff !== 0 || minorDiff !== 0 || patchDiff !== 0) {
+    let message;
+    if (majorDiff !== 0) {
+      className = majorDiff > 0 ? 'major-updates' : '';
+      message =
+        majorDiff > 0
+          ? simplur`${majorDiff} major version[|s] behind`
+          : simplur`${-majorDiff} major version[|s] ahead of`;
+    } else if (minorDiff !== 0) {
+      className = minorDiff > 0 ? 'minor-updates' : '';
+      message =
+        minorDiff > 0
+          ? simplur`${minorDiff} minor version[|s] behind`
+          : simplur`${-minorDiff} minor version[|s] ahead of`;
+    } else if (patchDiff !== 0) {
+      className = patchDiff > 0 ? 'patch-updates' : '';
+      message =
+        patchDiff > 0
+          ? simplur`${patchDiff} patch version[|s] behind`
+          : simplur`${-patchDiff} patch version[|s] ahead of`;
+    }
+
+    content = (
+      <>
+        {message} {latestVersion} (<code>latest</code>)
+      </>
+    );
+  }
+
+  return (
+    <div
+      id="module-version"
+      className={cn(className, props.className)}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -1,4 +1,4 @@
-import { PackumentVersion } from '@npm/types';
+import { Packument, PackumentVersion } from '@npm/types';
 import { getModuleKey, parseModuleKey } from './module_util.js';
 
 export interface ModulePackage extends PackumentVersion {
@@ -14,6 +14,7 @@ type OldLicense = {
 
 export default class Module {
   package: ModulePackage;
+  packument?: Packument;
 
   static stub(moduleKey: string, error: Error) {
     const [name, version] = parseModuleKey(moduleKey) ?? {};
@@ -27,10 +28,12 @@ export default class Module {
 
   // TODO: This should take either ModulePackage or PackageJSON... but need to
   // be clear about the differences between the two!
-  constructor(pkg: ModulePackage) {
+  constructor(pkg: ModulePackage, packument?: Packument) {
     if (!pkg.name) {
       throw new Error(`Package name is required`);
     }
+
+    this.packument = packument;
 
     if (!pkg.maintainers) {
       pkg.maintainers = [];

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -63,7 +63,7 @@ async function fetchModuleFromNPM(
     throw new Error(`No version ${packumentVersion} found for ${moduleName}`);
   }
 
-  return new Module(packumentVersion);
+  return new Module(packumentVersion, packument);
 }
 
 async function fetchModuleFromURL(urlString: string) {


### PR DESCRIPTION
Adds a component in the module pane that shows how the module version compares to `latest`.

NOTE:  I disable this component when the user has "Colorize by:" active and set to something other than "Outdated Level".  I'm not 100% sure that's the right thing to do, but  the different color semantics felt a bit jarring.

![CleanShot 2023-10-18 at 21 53 26@2x](https://github.com/npmgraph/npmgraph/assets/164050/258db374-7b0e-4301-8d79-e53bac4280ed)
