### PR TITLE
fix: local modules properly resolve to one another

### DIFF
--- a/components/GraphPane/colorizers/OutdatedColorizer.tsx
+++ b/components/GraphPane/colorizers/OutdatedColorizer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { diff } from 'semver';
 import Module from '../../../lib/Module.js';
-import { fetchNPMPackument } from '../../../lib/ModuleCache.js';
+import { getNPMPackument } from '../../../lib/PackumentCache.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 import { LegendColor } from './LegendColor.js';
 
@@ -23,7 +23,7 @@ export default {
   async colorForModule(module: Module) {
     if (module.isLocal || module.isStub) return '';
 
-    const manifest = await fetchNPMPackument(module.name);
+    const manifest = await getNPMPackument(module.name);
 
     const latestVersion = manifest?.['dist-tags']?.latest ?? '';
 

--- a/lib/PackumentCache.ts
+++ b/lib/PackumentCache.ts
@@ -1,0 +1,62 @@
+import { Packument } from '@npm/types';
+import { REGISTRY_BASE_URL } from './ModuleCache.js';
+import PromiseWithResolvers, {
+  PromiseWithResolversType,
+} from './PromiseWithResolvers.js';
+import fetchJSON from './fetchJSON.js';
+
+const packumentCache = new Map<string, PackumentCacheEntry>();
+
+export type QueryType = 'exact' | 'name' | 'license' | 'maintainer';
+
+type PackumentCacheEntry = PromiseWithResolversType<Packument | undefined> & {
+  packument?: Packument; // Set once packument is loaded
+};
+
+export async function getNPMPackument(
+  moduleName: string,
+): PackumentCacheEntry['promise'] {
+  let cacheEntry = packumentCache.get(moduleName);
+  if (!cacheEntry) {
+    cacheEntry = PromiseWithResolvers() as PackumentCacheEntry;
+    packumentCache.set(moduleName, cacheEntry);
+
+    await fetchJSON<Packument>(`${REGISTRY_BASE_URL}/${moduleName}`, {
+      // Per
+      // https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
+      // we should arguably be using the 'Accept:
+      // application/vnd.npm.install-v1+json' header to reduce the request size.
+      // But that doesn't actually work.
+      //
+      // REF: https://github.com/npm/feedback/discussions/1014
+      //
+      // So instead we're sending 'application/json'.  The responses are smaller
+      // and we get full "version" objects, so we don't have to send follow-up
+      // requests.
+      headers: { Accept: 'application/json' },
+    })
+      .catch(err => {
+        console.warn(
+          `Failed to fetch packument for ${moduleName}`,
+          err.message,
+        );
+        return undefined;
+      })
+      .then(cacheEntry.resolve);
+  }
+
+  return cacheEntry.promise;
+}
+
+export function getCachedPackument(moduleName: string): Packument | undefined {
+  return packumentCache.get(moduleName)?.packument;
+}
+
+export function cachePackument(moduleName: string, packument: Packument): void {
+  let cacheEntry = packumentCache.get(moduleName);
+  if (!cacheEntry) {
+    cacheEntry = PromiseWithResolvers() as PackumentCacheEntry;
+    packumentCache.set(moduleName, cacheEntry);
+    cacheEntry.resolve(packument);
+  }
+}

--- a/lib/PromiseWithResolvers.ts
+++ b/lib/PromiseWithResolvers.ts
@@ -1,11 +1,11 @@
 export type PromiseWithResolversType<T> = {
-  promise: PromiseLike<T>;
-  resolve: (value: T | PromiseLike<T>) => void;
+  promise: Promise<T>;
+  resolve: (value: T | Promise<T>) => void;
   reject: (reason?: unknown) => void;
 };
 
 export default function <T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void;
+  let resolve!: (value: T | Promise<T>) => void;
   let reject!: (reason?: unknown) => void;
 
   const promise = new Promise<T>((res, rej) => {


### PR DESCRIPTION
While working on the new  `npmgraph-cli` (coming soon!), I discovered that local modules (modules defined in the `packages` field in the URL `hash`) don't properly resolve to one another.  This was caused by local modules not having a "Packument" that could be searched to find matching versions.

So... this PR adds that, in the form of a PackumentCache.  This actuallly kinda-sorta existed before in the form of the fetchJSON() cache, but that only came into play when making actual requests for packuments from the NPM registry... which we don't do for local modules, for obvious reasons.   Adding the PackumentCache, and injecting a stub packument for local modules, allows the module resolution code in ModuleCache to properly find local modules when doing semver-matching.

Before:
![CleanShot 2023-10-24 at 06 00 42@2x](https://github.com/npmgraph/npmgraph/assets/164050/a246844c-fcf4-4083-a085-8d5dd04ee450)

After:
![CleanShot 2023-10-24 at 06 01 27@2x](https://github.com/npmgraph/npmgraph/assets/164050/abacad9d-44f3-49e1-8d41-20ef5b202ffa)
