### PR TITLE
feat: module release timeline chart

### DIFF
--- a/components/ModulePane/ModuleNpmsIOScores.tsx
+++ b/components/ModulePane/ModuleNpmsIOScores.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Module from '../../lib/Module.js';
 import fetchJSON from '../../lib/fetchJSON.js';
 import { NPMSIOData } from '../../lib/fetch_types.js';

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -15,6 +15,7 @@ import ModuleBundleSize from './ModuleBundleSize.js';
 import ModuleNpmsIOScores from './ModuleNpmsIOScores.js';
 import styles from './ModulePane.module.scss';
 import { ModuleVersionInfo } from './ModuleVersionInfo.js';
+import { ReleaseTimeline } from './ReleaseTimeline.js';
 
 export default function ModulePane({
   selectedModules,
@@ -130,6 +131,8 @@ export default function ModulePane({
         {projectLink}
         <ExternalLink href={packageUrl}>package.json</ExternalLink>
       </div>
+
+      <ReleaseTimeline module={module} />
 
       <Section title="Bundle Size">
         <ModuleBundleSize module={module} />

--- a/components/ModulePane/ReleaseTimeline.module.scss
+++ b/components/ModulePane/ReleaseTimeline.module.scss
@@ -1,0 +1,64 @@
+.root {
+  border: solid 1px var(--bg1);
+  border-radius: 0.3rem;
+
+  width: 100%;
+  height: 8rem;
+}
+
+.legend {
+  display: flex;
+  justify-content: space-between;
+  margin-block-start: 0.5rem;
+
+  & .dotKey {
+    display: inline-block;
+    vertical-align: middle;
+    border-radius: 50%;
+    background-color: red;
+    width: 0.7em;
+    height: 0.7em;
+  }
+  .dotKeyMajor {
+    background-color: var(--bg-red);
+    width: 1em;
+    height: 1em;
+  }
+  .dotKeyMinor {
+    background-color: var(--bg-orange);
+  }
+  .dotKeyPatch {
+    background-color: var(--bg-yellow);
+  }
+  .dotKeyPrerelease {
+    background-color: var(--bg-blue);
+  }
+}
+
+svg {
+  cursor: default;
+
+  > .layer-grid {
+    stroke: var(--stroke-green);
+    opacity: 0.6;
+  }
+
+  .layer-major {
+    fill: var(--bg-red);
+  }
+  .layer-minor {
+    fill: var(--bg-orange);
+  }
+  .layer-patch {
+    fill: var(--bg-yellow);
+  }
+  .layer-prerelease {
+    fill: var(--bg-blue);
+  }
+}
+
+.xAxis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+}

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -1,0 +1,167 @@
+import { PackumentVersion } from '@npm/types';
+import Module from '../../lib/Module.js';
+
+import { SemVer } from 'semver';
+import semverParse from 'semver/functions/parse.js';
+import { cn } from '../../lib/dom.js';
+import useMeasure from '../../lib/useMeasure.js';
+import { Section } from '../Section.js';
+import styles from './ReleaseTimeline.module.scss';
+
+function timestring(t: number) {
+  return new Date(t).toISOString().replace(/T.*/, '');
+}
+
+export function ReleaseTimeline({ module }: { module: Module }) {
+  const [ref, { width: w, height: h }] = useMeasure<SVGSVGElement>();
+  if (!module.packument?.versions) return;
+
+  const { time, versions } = module.packument;
+
+  const byTime = Object.entries(versions)
+    .map(([key, version]) => {
+      return [
+        key,
+        {
+          ...version,
+          time: Date.parse(time[key]),
+          semver: semverParse(key),
+        } as PackumentVersion & {
+          time: number;
+          semver: SemVer;
+        },
+      ] as const;
+    })
+    .filter(([k]) => k !== 'createdconso' && k !== 'modified')
+    .sort(([, a], [, b]) => {
+      return a.time < b.time ? -1 : 0;
+    });
+
+  const majorMax = byTime.reduce((acc, [, v]) => v.semver.major, 0);
+  const majorSep = h / majorMax;
+  const vmax = majorMax * majorSep;
+
+  const tmin = byTime[0][1].time;
+  const tmax = Date.now(); // byTime[byTime.length - 1][1].time;
+
+  const layers = {
+    // Note: order here controls layering in SVG
+    grid: [] as JSX.Element[],
+    prerelease: [] as JSX.Element[],
+    patch: [] as JSX.Element[],
+    minor: [] as JSX.Element[],
+    major: [] as JSX.Element[],
+    text: [] as JSX.Element[],
+  };
+
+  function xForT(t: number) {
+    return ((t - tmin) / (tmax - tmin)) * w;
+  }
+
+  // Add grid lines for each year
+  for (
+    let year = new Date(tmin).getFullYear() + 1;
+    year <= new Date(tmax).getFullYear();
+    year++
+  ) {
+    const x = xForT(new Date(String(year)).getTime());
+    layers.grid.push(<line x1={x} y1={0} x2={x} y2={h} key={`year-${year}`} />);
+  }
+
+  // Add version dots and lines
+  for (const [key, version] of byTime) {
+    const { time, semver } = version;
+
+    if (!semver) continue;
+
+    const x = xForT(time);
+    const title = `${key} published ${timestring(time)}`;
+    const y = vmax - semver.major * majorSep;
+
+    let r = 10;
+
+    let layer: keyof typeof layers;
+    if (semver.prerelease.length) {
+      layer = 'prerelease';
+      r *= 0.4;
+    } else if (semver.patch) {
+      layer = 'patch';
+      r *= 0.4;
+    } else if (semver.minor) {
+      layer = 'minor';
+      r *= 0.4;
+    } else if (semver.major) {
+      layer = 'major';
+
+      // Add major-version grid line
+      // layers.grid.push(
+      //   <line x1={x} y1={y} x2={w} y2={y} key={`version-${version.version}`} />,
+      // );
+    } else {
+      continue;
+    }
+
+    layers[layer].push(
+      <g key={`dot=${key}`} className="dot">
+        <title>{title}</title>
+        <circle cx={x} cy={y} r={r} />
+        {
+          // Major dots get a label
+          layer === 'major' ? (
+            <>
+              <title>{title}</title>
+
+              <text
+                x={x}
+                y={y}
+                textAnchor="middle"
+                alignmentBaseline="middle"
+                fill="white"
+              >
+                {semver.major}
+              </text>
+            </>
+          ) : null
+        }
+      </g>,
+    );
+  }
+
+  const xpad = w * 0.1;
+  const ypad = h * 0.1;
+
+  return (
+    <Section title="Release Timeline">
+      <svg
+        viewBox={`${-xpad} ${-ypad} ${w + xpad * 2} ${h + ypad * 2}`}
+        className={styles.root}
+        ref={ref}
+      >
+        {Object.entries(layers).map(([k, layer]) => {
+          return <g className={styles[`layer-${k}`]}>{layer}</g>;
+        })}
+      </svg>
+
+      <div className={styles.xAxis}>
+        <span>{timestring(tmin)}</span>
+        <span>today</span>
+      </div>
+
+      <div className={styles.legend}>
+        <span>
+          <span className={cn(styles.dotKey, styles.dotKeyMajor)} /> = major
+        </span>
+        <span>
+          <span className={cn(styles.dotKey, styles.dotKeyMinor)} /> = minor
+        </span>
+        <span>
+          <span className={cn(styles.dotKey, styles.dotKeyPatch)} /> = patch
+        </span>
+        <span>
+          <span className={cn(styles.dotKey, styles.dotKeyPrerelease)} /> =
+          prerelease
+        </span>
+      </div>
+    </Section>
+  );
+}

--- a/lib/useMeasure.ts
+++ b/lib/useMeasure.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useMeasure<T extends Element>() {
+  const ref = useRef<T>(null);
+
+  const [size, setSize] = useState({
+    width: 0,
+    height: 0,
+  });
+  const target = ref.current;
+
+  useEffect(() => {
+    setSize({
+      width: ref.current?.clientWidth ?? 0,
+      height: ref.current?.clientHeight ?? 0,
+    });
+
+    // if (!target) return;
+
+    // const observer = new ResizeObserver(entries => {
+    //   const entry = entries[0];
+    //   if (!entry) return;
+    //   const { inlineSize: width, blockSize: height } = entry.borderBoxSize[0];
+
+    //   setSize({ width, height });
+    // });
+
+    // observer.observe(target);
+
+    // return () => observer.unobserve(target);
+  }, [target]);
+
+  return [ref, size] as const;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npmgraph",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npmgraph",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/fregante"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npmgraph",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "module",
   "author": {
     "name": "Robert Kieffer",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "skipLibCheck": true,
-    "target": "ES2020",
+    "target": "ES2022",
     "moduleResolution": "nodenext",
     "module": "nodenext",
     "strict": true,


### PR DESCRIPTION
Adds a chart in the module pane that shows a scatter-graph-esque plot of the module release history.  For example (`express`):

<img width="417" alt="CleanShot 2023-12-04 at 07 35 24@2x" src="https://github.com/npmgraph/npmgraph/assets/164050/69f96eb5-084b-4680-9378-4b29fc1cc502">

'Threw this together this weekend on a bit of a whim.  Clicking around on different modules it's actually pretty interesting.  'Does a really good job at communicating the pace of change of a module over time,  and also speaks to how well-maintained a module is.