### PR TITLE
Fix return value for hasExpectedFeatures

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -16,7 +16,7 @@ function hasExpectedFeatures() {
   if (!window.fetch) return false;
   if (!window.AbortSignal?.timeout) return false;
 
-  return false;
+  return true;
 }
 
 function renderUnsupported() {


### PR DESCRIPTION
Previously this method would always return false regardless of whether the expected features are found or not.

Fixes a regression in https://github.com/npmgraph/npmgraph/pull/200