### PR TITLE
fix: show appropriate inspector pane on page load

### DIFF
--- a/components/App/App.tsx
+++ b/components/App/App.tsx
@@ -3,11 +3,23 @@ import LoadActivity from '../../lib/LoadActivity.js';
 import sharedStateHook from '../../lib/sharedStateHook.js';
 import GraphDiagram from '../GraphDiagram/GraphDiagram.js';
 import { GraphState } from '../GraphDiagram/graph_util.js';
-import Inspector from '../Inspector.js';
+import Inspector, { PANE } from '../Inspector.js';
 import './App.scss';
 import { Loader } from './Loader.js';
+import URLPlus from '../../lib/URLPlus.js';
 
-export const [usePane] = sharedStateHook('info', 'pane');
+function _getInitialPane() {
+  const loc = new URLPlus(location.href);
+  if (!loc.getSearchParam('q')) {
+    return PANE.INFO;
+  }
+  const select = loc.getHashParam('select')?.split(/[, ]+/);
+  return select ? PANE.MODULE : PANE.GRAPH;
+}
+
+const initialPane = _getInitialPane();
+console.log('initialPane', initialPane);
+export const [usePane] = sharedStateHook(initialPane, 'pane');
 export const [useGraph] = sharedStateHook(null as GraphState | null, 'graph');
 
 export default function App() {

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -40,6 +40,7 @@ import {
   gatherSelectionInfo,
   getGraphForQuery,
 } from './graph_util.js';
+import { PANE } from '../Inspector.js';
 
 export type ZoomOption =
   | typeof ZOOM_NONE
@@ -115,7 +116,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
     if (el) setZenMode('');
 
     setGraphSelection('exact', moduleKey);
-    setPane(moduleKey ? 'module' : 'graph');
+    setPane(moduleKey ? PANE.MODULE : PANE.GRAPH);
   }
 
   function applyZoom() {
@@ -275,8 +276,6 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
           el.classList.add('stub');
         }
       }
-
-      setPane(graph?.moduleInfos.size ? 'graph' : 'info');
 
       // Signal other hooks that graph DOM has changed
       setDomSignal(domSignal + 1);

--- a/components/InfoPane/QueryInput.tsx
+++ b/components/InfoPane/QueryInput.tsx
@@ -6,10 +6,13 @@ import useLocation from '../../lib/useLocation.js';
 import { useQuery } from '../../lib/useQuery.js';
 import { ExternalLink } from '../ExternalLink.js';
 import './QueryInput.scss';
+import { usePane } from '../App/App.js';
+import { PANE } from '../Inspector.js';
 
 export default function QueryInput(props: HTMLProps<HTMLInputElement>) {
   const [query] = useQuery();
   const [location, setLocation] = useLocation();
+  const [, setPane] = usePane();
 
   const initialValue = query.join(', ');
 
@@ -39,6 +42,7 @@ export default function QueryInput(props: HTMLProps<HTMLInputElement>) {
     url.hash = '';
 
     setLocation(url, false);
+    setPane(PANE.GRAPH);
   }
 
   return (

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -15,6 +15,13 @@ import ModulePane from './ModulePane/ModulePane.js';
 import { Splitter } from './Splitter.js';
 import { Tab } from './Tab.js';
 
+export enum PANE {
+  MODULE = 'module',
+  GRAPH = 'graph',
+  INFO = 'info',
+  ABOUT = 'about',
+}
+
 export default function Inspector(props: HTMLProps<HTMLDivElement>) {
   const [pane, setPane] = usePane();
   const [queryType, queryValue] = useGraphSelection();
@@ -26,18 +33,18 @@ export default function Inspector(props: HTMLProps<HTMLDivElement>) {
 
   let paneComponent;
   switch (pane) {
-    case 'module':
+    case PANE.MODULE:
       paneComponent = (
         <ModulePane id="pane-module" selectedModules={selectedModules} />
       );
       break;
-    case 'graph':
+    case PANE.GRAPH:
       paneComponent = <GraphPane id="pane-graph" graph={graph} />;
       break;
-    case 'info':
+    case PANE.INFO:
       paneComponent = <InfoPane id="pane-info" />;
       break;
-    case 'about':
+    case PANE.ABOUT:
       paneComponent = <AboutPane id="pane-about" />;
       break;
   }
@@ -45,18 +52,18 @@ export default function Inspector(props: HTMLProps<HTMLDivElement>) {
   return (
     <div id="inspector" className={hide !== null ? '' : 'open'} {...props}>
       <div id="tabs">
-        <Tab active={pane == 'info'} onClick={() => setPane('info')}>
+        <Tab active={pane == PANE.INFO} onClick={() => setPane(PANE.INFO)}>
           Start
         </Tab>
-        <Tab active={pane == 'graph'} onClick={() => setPane('graph')}>
+        <Tab active={pane == PANE.GRAPH} onClick={() => setPane(PANE.GRAPH)}>
           Graph
         </Tab>
-        <Tab active={pane == 'module'} onClick={() => setPane('module')}>
+        <Tab active={pane == PANE.MODULE} onClick={() => setPane(PANE.MODULE)}>
           Module
         </Tab>
         <Tab
-          active={pane == 'about'}
-          onClick={() => setPane('about')}
+          active={pane == PANE.ABOUT}
+          onClick={() => setPane(PANE.ABOUT)}
           badge={newCommitsCount > 0}
         >
           About

--- a/components/QueryLink.tsx
+++ b/components/QueryLink.tsx
@@ -2,6 +2,8 @@ import filterAlteredClicks from 'filter-altered-clicks';
 import React, { HTMLProps } from 'react';
 import { PARAM_QUERY } from '../lib/constants.js';
 import useLocation from '../lib/useLocation.js';
+import { usePane } from './App/App.js';
+import { PANE } from './Inspector.js';
 
 export function QueryLink({
   query,
@@ -13,6 +15,7 @@ export function QueryLink({
   query: string | string[];
 }) {
   const [location, setLocation] = useLocation();
+  const [, setPane] = usePane();
 
   const queries = Array.isArray(query) ? query : [query];
 
@@ -22,6 +25,7 @@ export function QueryLink({
 
   function onClick(e: React.MouseEvent) {
     e.preventDefault();
+    setPane(PANE.GRAPH);
     setLocation(url, false);
   }
 


### PR DESCRIPTION
'Fixing an issue where clicking a shared link that has a module selection (`select` hash param) opens the inspector to the `graph` pane of the 'module' pane.

For example, [this link](https://npmgraph.js.org/?q=sshpk#select=exact%3Aecc-jsbn%400.1.2) should look like this:
![CleanShot 2024-02-08 at 07 28 17@2x](https://github.com/npmgraph/npmgraph/assets/164050/c1f6be6a-78c9-490e-ac1d-377d0cc47f4b)

... but actually looks like this:
![CleanShot 2024-02-08 at 07 29 02@2x](https://github.com/npmgraph/npmgraph/assets/164050/0e3520cb-f3e3-4501-a6a5-a054fa2965e3)
