### PR TITLE
chore: add .gitattributes enforcing LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf


### PR DESCRIPTION
By default `autocrlf` is `true` on Windows so this ensures only LF is used regardless