### PR TITLE
Keeps tabs visible while loading

### DIFF
--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -1,6 +1,7 @@
 .loader {
   position: absolute;
   right: 0;
+  bottom: 0;
   z-index: 99;
   box-sizing: border-box;
   background: var(--tabs-bg) var(--bg-gradient);


### PR DESCRIPTION
When the loader overlaps the tabs, it's impossible to do anything, you just have to wait. This is particularly a problem when the package is large: https://npmgraph.js.org/?q=web-ext

<img width="864" alt="Screenshot 15" src="https://github.com/user-attachments/assets/cea05111-5989-4caf-8110-d46ebd7c9dbd">



This PR just moves the bar to the bottom as a quick fix:

<img width="864" alt="Screenshot" src="https://github.com/user-attachments/assets/b52cad4d-c30b-43ae-a20f-0e7782b93f7a">

Combined with #224 it will look better down there.