### PR TITLE
Revert "Keeps tabs visible while loading"

### DIFF
--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -1,7 +1,6 @@
 .loader {
   position: absolute;
   right: 0;
-  bottom: 0;
   z-index: 99;
   box-sizing: border-box;
   background: var(--tabs-bg) var(--bg-gradient);


### PR DESCRIPTION
Reverts npmgraph/npmgraph#227

I think it's not a good position, it's hard to notice anything is happening. I think it needs to stay on top. Either we revert this for now (and I open a tracking issue) or I move it to the top left corner instead, with rounded corners perhaps.