### PR TITLE
fix: handle npm:-style dependency aliases, fixes #143

### DIFF
--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -1,6 +1,10 @@
 import { Maintainer, Packument, PackumentVersion } from '@npm/types';
 import { isDefined } from './guards.js';
-import { getModuleKey, parseModuleKey } from './module_util.js';
+import {
+  getModuleKey,
+  parseModuleKey,
+  resolveDependencyAliases,
+} from './module_util.js';
 
 type DeprecatedLicense = {
   type: string;
@@ -28,8 +32,7 @@ export default class Module {
     }
 
     this.packument = packument;
-
-    this.package = pkg;
+    this.package = resolveDependencyAliases(pkg);
   }
 
   get key() {

--- a/lib/module_util.ts
+++ b/lib/module_util.ts
@@ -5,16 +5,6 @@ export function isHttpModule(moduleKey: string) {
 }
 
 export function resolveModule(name: string, version?: string) {
-  // "npm:<package name>@<version>"-style names are used to create aliases.  We
-  // detect that here and massage the inputs accordingly
-  //
-  // See `@isaacs/cliui` package for an example.
-  if (version?.startsWith('npm:')) {
-    name = version.slice(4);
-    version = undefined;
-    // Important: Fall through so name is parsed, below...
-  }
-
   if (!version) {
     // Parse versioned-names (e.g. "less@1.2.3")
     [name, version] = parseModuleKey(name);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
+    "lib": ["ES2022", "dom"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "resolveJsonModule": true,


### PR DESCRIPTION
Here's what the fixed graph from #143 looks like after this change:

![CleanShot 2024-07-14 at 18 27 19@2x](https://github.com/user-attachments/assets/62a2d187-955e-42bd-b8e4-8bd78424a163)



This PR adds code that [rather forcefully] resolves "npm:..."-style aliases in `package#*dependencies` structures so they point to the source unaliased package.  Solution is a bit heavy-handed (I'd rather not mutate package structures) but it fixes the problem at the source, and the aliased names are only relevant when it comes to the name used to save packages in node_modules directories on disk.
