### PR TITLE
feat: keeps tabs visible while loading

### DIFF
--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -11,7 +11,6 @@
 
   overflow: hidden;
   pointer-events: none;
-  color: var(--tabs-text);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -1,17 +1,20 @@
 .loader {
   position: absolute;
-  right: 0;
+  left: 0;
   z-index: 99;
   box-sizing: border-box;
-  background: var(--tabs-bg) var(--bg-gradient);
-  padding-left: 0.5em;
-  width: var(--inspector-size);
+  background: var(--root-bg);
+  box-shadow: 2px 2px 10px 5px var(--root-bg);
+  padding: 0.5em;
+  max-width: var(--inspector-size);
+  border-bottom-right-radius: 1em;
+
   overflow: hidden;
   color: var(--tabs-text);
   font-weight: 600;
-  line-height: var(--tabs-height);
   text-overflow: ellipsis;
   white-space: nowrap;
+  pointer-events: none;
 
   @keyframes MOVE-BG {
     from {
@@ -22,22 +25,24 @@
     }
   }
 
-  .bg {
-    position: absolute;
-    bottom: 0;
-    z-index: -1;
-    animation-duration: 1.6s;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
-    animation-name: MOVE-BG;
-    background: repeating-linear-gradient(
-      -45deg,
-      white 0,
-      white 20px,
-      var(--highlight) 20px,
-      var(--highlight) 40px
-    );
-    width: calc(100% + 57px);
-    height: 2pt;
-  }
+}
+
+.progress-bar {
+  position: absolute;
+  inset: 0;
+  width: calc(100% + 57px);
+  height: 2pt;
+  z-index: 9999;
+
+  animation-duration: 1.6s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  animation-name: MOVE-BG;
+  background: repeating-linear-gradient(
+    -45deg,
+    white 0,
+    white 20px,
+    var(--highlight) 20px,
+    var(--highlight) 40px
+  );
 }

--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -3,18 +3,18 @@
   left: 0;
   z-index: 99;
   box-sizing: border-box;
-  background: var(--root-bg);
   box-shadow: 2px 2px 10px 5px var(--root-bg);
+  border-bottom-right-radius: 1em;
+  background: var(--root-bg);
   padding: 0.5em;
   max-width: var(--inspector-size);
-  border-bottom-right-radius: 1em;
 
   overflow: hidden;
+  pointer-events: none;
   color: var(--tabs-text);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
-  pointer-events: none;
 
   @keyframes MOVE-BG {
     from {
@@ -24,20 +24,17 @@
       transform: translateX(0);
     }
   }
-
 }
 
 .progress-bar {
   position: absolute;
-  inset: 0;
-  width: calc(100% + 57px);
-  height: 2pt;
   z-index: 9999;
 
   animation-duration: 1.6s;
   animation-timing-function: linear;
   animation-iteration-count: infinite;
   animation-name: MOVE-BG;
+  inset: 0;
   background: repeating-linear-gradient(
     -45deg,
     white 0,
@@ -45,4 +42,6 @@
     var(--highlight) 20px,
     var(--highlight) 40px
   );
+  width: calc(100% + 57px);
+  height: 2pt;
 }

--- a/components/App/Loader.scss
+++ b/components/App/Loader.scss
@@ -3,9 +3,9 @@
   left: 0;
   z-index: 99;
   box-sizing: border-box;
-  box-shadow: 2px 2px 10px 5px var(--root-bg);
+  box-shadow: 2px 2px 10px 5px var(--bg-root);
   border-bottom-right-radius: 1em;
-  background: var(--root-bg);
+  background: var(--bg-root);
   padding: 0.5em;
   max-width: var(--inspector-size);
 

--- a/components/App/Loader.tsx
+++ b/components/App/Loader.tsx
@@ -7,9 +7,11 @@ export function Loader({
   activity,
 }: { activity: LoadActivity } & HTMLProps<HTMLDivElement>) {
   return (
+    <>
+    <div className="progress-bar" />
     <div className="loader">
-      <div className="bg" />
       {activity.title} ...
     </div>
+    </>
   );
 }

--- a/components/App/Loader.tsx
+++ b/components/App/Loader.tsx
@@ -8,10 +8,8 @@ export function Loader({
 }: { activity: LoadActivity } & HTMLProps<HTMLDivElement>) {
   return (
     <>
-    <div className="progress-bar" />
-    <div className="loader">
-      {activity.title} ...
-    </div>
+      <div className="progress-bar" />
+      <div className="loader">{activity.title} ...</div>
     </>
   );
 }

--- a/index.scss
+++ b/index.scss
@@ -17,6 +17,7 @@
 
   --text: #020303;
   --text-dim: #999;
+  --bg-root: #fff;
   --bg0: #f1f4f4;
   --bg1: #bbb;
   --bg2: #ddd;
@@ -65,10 +66,9 @@
       --grey#{(10-$i) * 10}: hsl(0, 0%, #{$i * 10%});
     }
 
-    background-color: #111;
-
     --text: #f3f3f3;
     --text-dim: #766;
+    --bg-root: #111;
     --bg0: #262222;
     --bg1: #696666;
     --bg2: #333;
@@ -83,6 +83,7 @@
 }
 
 html {
+  background: var(--bg-root);
   font-size: 10pt;
   font-family:
     system-ui,


### PR DESCRIPTION
Retry of https://github.com/npmgraph/npmgraph/pull/227

- The bar is moved to the top border, like GitHub.com does for example
- The activity ticker is moved to the top left, without a background. If there's text below it, it appears as a shadow:

https://github.com/user-attachments/assets/2d24f2be-49dc-4ec0-a221-5e6f018247d3


