### PR TITLE
feat: allow opening modules in a new tab

### DIFF
--- a/components/GraphDiagram/GraphDiagram.scss
+++ b/components/GraphDiagram/GraphDiagram.scss
@@ -94,20 +94,20 @@ g.node {
   }
 
   &.selected {
-    & > path {
+    path {
       stroke-width: 3;
       stroke: var(--highlight) !important;
     }
   }
 
   &.upstream {
-    & > path {
+    path {
       stroke: var(--stroke-blue);
     }
   }
 
   &.downstream {
-    & > path {
+    path {
       stroke: var(--stroke-violet);
     }
   }

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -74,7 +74,10 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
   const [domSignal, setDomSignal] = useState(0);
 
   async function handleGraphClick(event: React.MouseEvent) {
-    if (!(event.target instanceof Element) || event.target.closest('#graph-controls'))
+    if (
+      !(event.target instanceof Element) ||
+      event.target.closest('#graph-controls')
+    )
       return;
 
     if (event.metaKey) {

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -90,7 +90,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
       // Don't navigate to link
       event.preventDefault();
     }
-    
+
     const moduleKey = node ? $('title', node)?.textContent?.trim() : '';
     const module = moduleKey ? getCachedModule(moduleKey) : undefined;
 

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -73,16 +73,21 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
   // Signal for when Graph DOM changes
   const [domSignal, setDomSignal] = useState(0);
 
-  async function handleGraphClick({ target, shiftKey }: React.MouseEvent) {
-    if (!(target instanceof Element) || target.closest('#graph-controls'))
+  async function handleGraphClick(event: React.MouseEvent) {
+    if (!(event.target instanceof Element) || event.target.closest('#graph-controls'))
       return;
 
-    const node = target.closest('g.node');
+    if (event.metaKey) {
+      // Allow opening the link in a new tab
+      return;
+    }
+
+    const node = event.target.closest('g.node');
     const moduleKey = node ? $('title', node)?.textContent?.trim() : '';
     const module = moduleKey ? getCachedModule(moduleKey) : undefined;
 
     // Toggle exclude filter?
-    if (node && shiftKey) {
+    if (node && event.shiftKey) {
       if (module) {
         const isIncluded = collapse.includes(module.name);
         if (isIncluded) {
@@ -92,6 +97,7 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
         }
       }
 
+      event.preventDefault();
       return;
     }
 

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -86,6 +86,11 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
     }
 
     const node = event.target.closest('g.node');
+    if (node) {
+      // Don't navigate to link
+      event.preventDefault();
+    }
+    
     const moduleKey = node ? $('title', node)?.textContent?.trim() : '';
     const module = moduleKey ? getCachedModule(moduleKey) : undefined;
 
@@ -100,7 +105,6 @@ export default function GraphDiagram({ activity }: { activity: LoadActivity }) {
         }
       }
 
-      event.preventDefault();
       return;
     }
 

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -218,7 +218,9 @@ export function composeDOT({
       fontsize *= Math.max(1, Math.log10(unpackedSize) - 2);
     }
 
-    const vs = { root: level == 0, fontsize };
+    const link = new URL(location.origin);
+    link.searchParams.append('q', module.key);
+    const vs = { root: level == 0, fontsize, href: link.href };
 
     nodes.push(`"${dotEscape(module.key)}" ${vizStyle(vs)}`);
 
@@ -245,7 +247,7 @@ export function composeDOT({
     );
   }
 
-  return [
+  const x= [
     'digraph {',
     'rankdir="LR"',
     'labelloc="t"',
@@ -268,6 +270,8 @@ export function composeDOT({
     )
     .concat('}')
     .join('\n');
+    console.log(x)
+    return x;
 }
 
 export function foreachUpstream(

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -247,7 +247,7 @@ export function composeDOT({
     );
   }
 
-  const x= [
+  const x = [
     'digraph {',
     'rankdir="LR"',
     'labelloc="t"',
@@ -270,8 +270,8 @@ export function composeDOT({
     )
     .concat('}')
     .join('\n');
-    console.log(x)
-    return x;
+  console.log(x);
+  return x;
 }
 
 export function foreachUpstream(

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -247,7 +247,7 @@ export function composeDOT({
     );
   }
 
-  const x = [
+  return [
     'digraph {',
     'rankdir="LR"',
     'labelloc="t"',
@@ -270,8 +270,6 @@ export function composeDOT({
     )
     .concat('}')
     .join('\n');
-  console.log(x);
-  return x;
 }
 
 export function foreachUpstream(


### PR DESCRIPTION
Sometimes I just want to explore a module in a new tab. This enables it via the standard cmd+click.

I think `metaKey` doesn't work on Windows so if accepted I'll have to do ua-sniffing and enable it on `ctrlKey` as well.