### PR TITLE
fix: hide Go button if there's nothing to change

### DIFF
--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -88,6 +88,9 @@ export default function ModulePane({
     });
   }
 
+  const isSingleEntryModule =
+    graph.entryModules.size === 1 &&
+    [...graph.entryModules][0].key === module.key;
   const maintainers = module.maintainers;
 
   const npmUrl = `https://www.npmjs.com/package/${module.name}/v/${module.version}`;
@@ -121,13 +124,15 @@ export default function ModulePane({
       <p style={{ marginTop: 0 }}>{pkg?.description}</p>
 
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <QueryLink
-          className="bright-hover"
-          query={module.key}
-          style={{ textDecoration: 'none' }}
-        >
-          ← Go
-        </QueryLink>
+        {isSingleEntryModule ? null : (
+          <QueryLink
+            className="bright-hover"
+            query={module.key}
+            style={{ textDecoration: 'none' }}
+          >
+            ← Go
+          </QueryLink>
+        )}
         <ExternalLink href={npmUrl} icon={NpmIcon}>
           npm
         </ExternalLink>

--- a/index.scss
+++ b/index.scss
@@ -28,7 +28,7 @@
   --tabs-text: #fff;
   --tabs-border: rgba(203, 203, 203, 0.796);
 
-  --accent: #e65c00;
+  --accent: #da6200;
   --text-on-accent: #fff;
 
   // Shadow colors depend on the background color


### PR DESCRIPTION
- Closes https://github.com/npmgraph/npmgraph/issues/246

## Normal (non-entry module selected)

<img width="953" alt="Screenshot 8" src="https://github.com/user-attachments/assets/f3007f76-3fc9-4190-b61d-7e15ae6ae2e2">

## No Go (entry module selected)

<img width="953" alt="Screenshot 7" src="https://github.com/user-attachments/assets/1294176c-3260-43f3-b6a5-cd327e2d96ef">

## Normal (entry module selected, but not the only entry module)

<img width="953" alt="Screenshot 9" src="https://github.com/user-attachments/assets/ddbcf55e-32df-4d53-a956-4324fca1e4cc">

