### PR TITLE
chore: various fixes around CI and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,4 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
-      - run: npm test
+      - run: npm run build
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run lint && npm run format:check
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run types

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,10 @@
 name: PR
 
 on:
-  - pull_request
+  pull_request:
+    types:
+      - opened
+      - edited
 
 jobs:
   title:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Does it follow the conventional commit format?
-        if: !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'chore:')
+        if: ${{ !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'chore:') }}
         run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,12 @@
+name: PR
+
+on:
+  - pull_request
+
+jobs:
+  title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Does it follow the conventional commit format?
+        if: !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'chore:')
+        run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,5 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - name: Does it follow the conventional commit format?
-        if: ${{ !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'chore:') }}
-        run: exit 1
+      - name: Does it follow the conventional commit format? ${{github.event.pull_request.title}}
+        run: exit ${{ (startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'chore:')) && 0 || 1 }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,6 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - name: Does it follow the conventional commit format? ${{github.event.pull_request.title}}
-        run: exit ${{ (startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'chore:')) && 0 || 1 }}
+      - name: 'Validate: ${{github.event.pull_request.title}}'
+        if: ${{ !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'chore:') }}
+        run: exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.1.3",
+        "npm-run-all2": "^6.2.2",
         "parcel": "^2.12.0",
         "postcss": "8.4.39",
         "postcss-modules": "4.3.1",
@@ -5644,6 +5645,15 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/meow": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
@@ -6039,6 +6049,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-all2": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-6.2.2.tgz",
+      "integrity": "sha512-Q+alQAGIW7ZhKcxLt8GcSi3h3ryheD6xnmXahkMRVM5LYmajcUrSITm8h+OPC9RYWMV2GR0Q1ntTUCfxaNoOJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "cross-spawn": "^7.0.3",
+        "memorystream": "^0.3.1",
+        "minimatch": "^9.0.0",
+        "pidtree": "^0.6.0",
+        "read-package-json-fast": "^3.0.2",
+        "shell-quote": "^1.7.3"
+      },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "npm-run-all2": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">= 8"
+      }
+    },
+    "node_modules/npm-run-all2/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -6247,6 +6306,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/pify": {
@@ -6634,6 +6706,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-package-json-fast": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-3.0.2.tgz",
+      "integrity": "sha512-0J+Msgym3vrLOUB3hzQCuZHII0xkNGCtz/HJH9xZshwv9DbDwkw1KaE3gx/e2J5rpEY5rtOy6cyhKOPrkP7FZw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^3.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json-fast/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -6993,6 +7089,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/simplur": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
+    "npm-run-all2": "^6.2.2",
     "parcel": "^2.12.0",
     "postcss": "8.4.39",
     "postcss-modules": "4.3.1",
@@ -83,9 +84,10 @@
     "release": "standard-version",
     "start": "parcel serve index.html",
     "lint": "eslint .",
+    "fix": "run-p 'lint -- --fix' format:fix",
     "format:check": "prettier -c .",
     "format:fix": "prettier -w .",
     "types": "tsc --noEmit",
-    "test": "npm run format:check && npm run lint && npm run types"
+    "test": "run-p format:check lint types build"
   }
 }


### PR DESCRIPTION
- Include `build` in `npm test` (it was missing)
- Run `npm test` sub-commands in parallel
- Add `npm run fix` to run both `eslint --fix` and `prettier --write`
- Split up CI jobs so you know immediately which test failed, independently (lint, build, types)