### PR TITLE
chore: cleanup lint config and apply new rules

### DIFF
--- a/components/AboutPane/AboutPane.tsx
+++ b/components/AboutPane/AboutPane.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { ExternalLink } from '../ExternalLink.js';
 import { GithubIcon } from '../Icons.js';
 import { Pane } from '../Pane.js';

--- a/components/AboutPane/AboutPane.tsx
+++ b/components/AboutPane/AboutPane.tsx
@@ -3,9 +3,9 @@ import { ExternalLink } from '../ExternalLink.js';
 import { GithubIcon } from '../Icons.js';
 import { Pane } from '../Pane.js';
 import './AboutPane.scss';
+import { version as VERSION } from '../../package.json';
 import { CommitList } from './CommitList.js';
 import GithubSponsorButton from './GithubSponsorButton.js';
-import { version as VERSION } from '../../package.json';
 
 export default function AboutPane(props: HTMLProps<HTMLDivElement>) {
   return (

--- a/components/AboutPane/CommitList.tsx
+++ b/components/AboutPane/CommitList.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, useEffect } from 'react';
+import React, { type HTMLProps, useEffect } from 'react';
 import simplur from 'simplur';
 import { ago } from '../../lib/ago.js';
 import { cn } from '../../lib/dom.js';

--- a/components/AboutPane/CommitList.tsx
+++ b/components/AboutPane/CommitList.tsx
@@ -46,7 +46,8 @@ export function CommitList({ className, ...props }: HTMLProps<HTMLDivElement>) {
   return (
     <div id="commit-list">
       <div id="commit-list-header">
-        Recent changes{newCount > 0 ? simplur` (${newCount} new)` : null}
+        Recent changes
+        {newCount > 0 ? simplur` (${newCount} new)` : null}
       </div>
 
       <div className={cn('commit-list', className)} {...props}>

--- a/components/AboutPane/GithubSponsorButton.tsx
+++ b/components/AboutPane/GithubSponsorButton.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { cn } from '../../lib/dom.js';
 import { SponsorIcon } from '../Icons.js';
 import './GithubSponsorButton.scss';

--- a/components/App/App.tsx
+++ b/components/App/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import LoadActivity from '../../lib/LoadActivity.js';
+import type LoadActivity from '../../lib/LoadActivity.js';
 import GraphDiagram from '../GraphDiagram/GraphDiagram.js';
 import Inspector from '../Inspector.js';
 import './App.scss';

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,6 +1,6 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { cn } from '../lib/dom.js';
-import { IconProps, OffsiteLinkIcon } from './Icons.js';
+import { type IconProps, OffsiteLinkIcon } from './Icons.js';
 
 import './ExternalLink.scss';
 

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -1,6 +1,7 @@
 import { Graphviz } from '@hpcc-js/wasm/graphviz';
 import { select } from 'd3-selection';
 import React, { useEffect, useState } from 'react';
+import { $, $$ } from 'select-dom';
 import { useGlobalState } from '../../lib/GlobalStore.js';
 import type LoadActivity from '../../lib/LoadActivity.js';
 import type Module from '../../lib/Module.js';
@@ -21,7 +22,6 @@ import {
   ZOOM_NONE,
 } from '../../lib/constants.js';
 import { createAbortable } from '../../lib/createAbortable.js';
-import { $, $$ } from 'select-dom';
 import { flash } from '../../lib/flash.js';
 import useCollapse from '../../lib/useCollapse.js';
 import useGraphSelection from '../../lib/useGraphSelection.js';

--- a/components/GraphDiagram/GraphDiagram.tsx
+++ b/components/GraphDiagram/GraphDiagram.tsx
@@ -2,10 +2,10 @@ import { Graphviz } from '@hpcc-js/wasm/graphviz';
 import { select } from 'd3-selection';
 import React, { useEffect, useState } from 'react';
 import { useGlobalState } from '../../lib/GlobalStore.js';
-import LoadActivity from '../../lib/LoadActivity.js';
-import Module from '../../lib/Module.js';
+import type LoadActivity from '../../lib/LoadActivity.js';
+import type Module from '../../lib/Module.js';
 import {
-  QueryType,
+  type QueryType,
   getCachedModule,
   queryModuleCache,
 } from '../../lib/ModuleCache.js';
@@ -36,8 +36,8 @@ import './GraphDiagram.scss';
 import GraphDiagramDownloadButton from './GraphDiagramDownloadButton.js';
 import { GraphDiagramZoomButtons } from './GraphDiagramZoomButtons.js';
 import {
-  DependencyKey,
-  GraphState,
+  type DependencyKey,
+  type GraphState,
   composeDOT,
   gatherSelectionInfo,
   getGraphForQuery,

--- a/components/GraphDiagram/GraphDiagramDownloadButton.tsx
+++ b/components/GraphDiagram/GraphDiagramDownloadButton.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
+import indexStyles from 'bundle-text:../../index.scss';
+import diagramStyles from 'bundle-text:./GraphDiagram.scss';
 import { report } from '../../lib/bugsnag.js';
 import { DownloadIcon } from '../Icons.js';
 import { getDiagramElement } from './GraphDiagram.js';
-
-import indexStyles from 'bundle-text:../../index.scss';
-import diagramStyles from 'bundle-text:./GraphDiagram.scss';
 
 type DownloadExtension = 'svg' | 'png';
 

--- a/components/GraphDiagram/GraphDiagramZoomButtons.tsx
+++ b/components/GraphDiagram/GraphDiagramZoomButtons.tsx
@@ -14,7 +14,7 @@ export function GraphDiagramZoomButtons() {
   return (
     <>
       <button
-        className={cn({ selected: zoom == ZOOM_FIT_WIDTH })}
+        className={cn({ selected: zoom === ZOOM_FIT_WIDTH })}
         onClick={() => setZoom(ZOOM_FIT_WIDTH)}
         title="zoom (fit width)"
         style={{ borderRadius: '3px 0 0 3px' }}
@@ -22,7 +22,7 @@ export function GraphDiagramZoomButtons() {
         <ZoomHorizontalIcon />
       </button>
       <button
-        className={cn({ selected: zoom == ZOOM_NONE })}
+        className={cn({ selected: zoom === ZOOM_NONE })}
         onClick={() => setZoom(ZOOM_NONE)}
         title="zoom (1:1)"
         style={{
@@ -36,7 +36,7 @@ export function GraphDiagramZoomButtons() {
         1:1
       </button>
       <button
-        className={cn({ selected: zoom == ZOOM_FIT_HEIGHT })}
+        className={cn({ selected: zoom === ZOOM_FIT_HEIGHT })}
         onClick={() => setZoom(ZOOM_FIT_HEIGHT)}
         title="zoom (fit height)"
         style={{ borderRadius: '0 3px 3px 0' }}

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -79,7 +79,7 @@ function getDependencyEntries(
     if (!deps) continue;
 
     // Only do one level for non-"dependencies"
-    if (level > 0 && type != 'dependencies') continue;
+    if (level > 0 && type !== 'dependencies') continue;
 
     // Get entries, adding type to each entry
     for (const [name, version] of Object.entries(deps)) {
@@ -201,7 +201,7 @@ export function composeDOT({
   // Sort modules by [level, key]
   const entries = [...graph.moduleInfos.entries()];
   entries.sort(([aKey, a], [bKey, b]) => {
-    if (a.level != b.level) {
+    if (a.level !== b.level) {
       return a.level - b.level;
     } else {
       return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
@@ -220,7 +220,7 @@ export function composeDOT({
 
     const link = new URL(location.origin);
     link.searchParams.append('q', module.key);
-    const vs = { root: level == 0, fontsize, href: link.href };
+    const vs = { root: level === 0, fontsize, href: link.href };
 
     nodes.push(`"${dotEscape(module.key)}" ${vizStyle(vs)}`);
 
@@ -235,7 +235,7 @@ export function composeDOT({
   }
 
   const titleParts = entries
-    .filter(([, m]) => m.level == 0)
+    .filter(([, m]) => m.level === 0)
     .map(([, m]) => dotEscape(m.module.name));
 
   const MAX_PARTS = 3;
@@ -263,7 +263,7 @@ export function composeDOT({
     .concat(
       graph.moduleInfos.size > 1
         ? `{rank=same; ${[...graph.moduleInfos.values()]
-            .filter(info => info.level == 0)
+            .filter(info => info.level === 0)
             .map(info => `"${info.module}"`)
             .join('; ')};}`
         : '',

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -1,5 +1,5 @@
 import simplur from 'simplur';
-import Module from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 import { getModule } from '../../lib/ModuleCache.js';
 import { getModuleKey } from '../../lib/module_util.js';
 

--- a/components/GraphPane/GraphPane.tsx
+++ b/components/GraphPane/GraphPane.tsx
@@ -6,7 +6,7 @@ import { PARAM_DEPENDENCIES, PARAM_SIZING } from '../../lib/constants.js';
 import { isDefined } from '../../lib/guards.js';
 import useCollapse from '../../lib/useCollapse.js';
 import { ExternalLink } from '../ExternalLink.js';
-import { DependencyKey, GraphState } from '../GraphDiagram/graph_util.js';
+import type { DependencyKey, GraphState } from '../GraphDiagram/graph_util.js';
 import { Pane } from '../Pane.js';
 import { Toggle } from '../Toggle.js';
 import ColorizeInput from './ColorizeInput.js';

--- a/components/GraphPane/ModuleTable.tsx
+++ b/components/GraphPane/ModuleTable.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Selectable } from '../Selectable.js';
 
-import Module from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 import styles from './ModuleTable.module.scss';
 
 export type ModuleTableData = Map<string, Module[]>;

--- a/components/GraphPane/colorizers/BusFactorColorizer.tsx
+++ b/components/GraphPane/colorizers/BusFactorColorizer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Module from '../../../lib/Module.js';
+import type Module from '../../../lib/Module.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 import { LegendColor } from './LegendColor.js';
 

--- a/components/GraphPane/colorizers/LegendColor.tsx
+++ b/components/GraphPane/colorizers/LegendColor.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 
 export function LegendColor({

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -1,5 +1,5 @@
-import { PackageJSON } from '@npm/types';
-import Module from '../../../lib/Module.js';
+import type { PackageJSON } from '@npm/types';
+import type Module from '../../../lib/Module.js';
 import { LegendColor } from './LegendColor.js';
 
 export const COLORIZE_MODULE_CJS = 'var(--bg-orange)';

--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import Module from '../../../lib/Module.js';
+import type Module from '../../../lib/Module.js';
 import PromiseWithResolvers from '../../../lib/PromiseWithResolvers.js';
 import fetchJSON from '../../../lib/fetchJSON.js';
-import { NPMSIOData } from '../../../lib/fetch_types.js';
+import type { NPMSIOData } from '../../../lib/fetch_types.js';
 import { flash } from '../../../lib/flash.js';
 import { hslFor } from '../../GraphDiagram/graph_util.js';
-import { BulkColorizer } from './index.js';
+import type { BulkColorizer } from './index.js';
 
 // Max number of module names allowed per NPMS request
 const NPMS_BULK_LIMIT = 250;

--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -72,7 +72,7 @@ class NPMSColorizer implements BulkColorizer {
     const combinedResults: { [key: string]: NPMSIOData } = {};
     let rejected = 0;
     for (const result of results) {
-      if (result.status == 'rejected') {
+      if (result.status === 'rejected') {
         rejected++;
       } else {
         Object.assign(combinedResults, result.value);

--- a/components/GraphPane/colorizers/OutdatedColorizer.tsx
+++ b/components/GraphPane/colorizers/OutdatedColorizer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { diff } from 'semver';
-import Module from '../../../lib/Module.js';
+import type Module from '../../../lib/Module.js';
 import { getNPMPackument } from '../../../lib/PackumentCache.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 import { LegendColor } from './LegendColor.js';

--- a/components/GraphPane/colorizers/index.ts
+++ b/components/GraphPane/colorizers/index.ts
@@ -1,4 +1,4 @@
-import Module from '../../../lib/Module.js';
+import type Module from '../../../lib/Module.js';
 import BusFactorColorizer from './BusFactorColorizer.js';
 import ModuleTypeColorizer from './ModuleTypeColorizer.js';
 import { NPMSOverallColorizer } from './NPMSColorizer.js';

--- a/components/GraphPane/reports/Analyzer.tsx
+++ b/components/GraphPane/reports/Analyzer.tsx
@@ -10,7 +10,10 @@
  * can generate state that is used by more than one renderer
  */
 
-import type { GraphModuleInfo, GraphState } from '../../GraphDiagram/graph_util.js';
+import type {
+  GraphModuleInfo,
+  GraphState,
+} from '../../GraphDiagram/graph_util.js';
 
 export type Analyzer2 = (graph: GraphState) => unknown;
 

--- a/components/GraphPane/reports/Analyzer.tsx
+++ b/components/GraphPane/reports/Analyzer.tsx
@@ -10,7 +10,7 @@
  * can generate state that is used by more than one renderer
  */
 
-import { GraphModuleInfo, GraphState } from '../../GraphDiagram/graph_util.js';
+import type { GraphModuleInfo, GraphState } from '../../GraphDiagram/graph_util.js';
 
 export type Analyzer2 = (graph: GraphState) => unknown;
 

--- a/components/GraphPane/reports/ReportItem.tsx
+++ b/components/GraphPane/reports/ReportItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { cn } from '../../../lib/dom.js';
-import { RenderedAnalysis } from './Analyzer.js';
+import type { RenderedAnalysis } from './Analyzer.js';
 import styles from './ReportItem.module.scss';
 
 const SYMBOLS = {

--- a/components/GraphPane/reports/analyzeLicenses.tsx
+++ b/components/GraphPane/reports/analyzeLicenses.tsx
@@ -1,6 +1,6 @@
-import Module from '../../../lib/Module.js';
-import { LICENSES, OSIKeyword } from '../../../lib/licenses.js';
-import { GraphState } from '../../GraphDiagram/graph_util.js';
+import type Module from '../../../lib/Module.js';
+import { LICENSES, type OSIKeyword } from '../../../lib/licenses.js';
+import type { GraphState } from '../../GraphDiagram/graph_util.js';
 
 export type LicenseAnalysisState = {
   modulesByLicense: Map<string, Module[]>;

--- a/components/GraphPane/reports/analyzeMaintainers.tsx
+++ b/components/GraphPane/reports/analyzeMaintainers.tsx
@@ -1,6 +1,7 @@
-import Module, { Maintainer } from '../../../lib/Module.js';
+import type { Maintainer } from '../../../lib/Module.js';
+import type Module from '../../../lib/Module.js';
 import { report } from '../../../lib/bugsnag.js';
-import { GraphState } from '../../GraphDiagram/graph_util.js';
+import type { GraphState } from '../../GraphDiagram/graph_util.js';
 
 export type MaintainerAnalysisState = {
   modulesByMaintainer: Map<string, Set<Module>>;

--- a/components/GraphPane/reports/analyzeModules.tsx
+++ b/components/GraphPane/reports/analyzeModules.tsx
@@ -1,5 +1,5 @@
-import Module from '../../../lib/Module.js';
-import { GraphState } from '../../GraphDiagram/graph_util.js';
+import type Module from '../../../lib/Module.js';
+import type { GraphState } from '../../GraphDiagram/graph_util.js';
 
 export type ModuleAnalysisState = GraphState & {
   versionsByName: Record<string, Module[]>;

--- a/components/GraphPane/reports/analyzePeerDependencies.tsx
+++ b/components/GraphPane/reports/analyzePeerDependencies.tsx
@@ -1,6 +1,6 @@
 import { satisfies } from 'semver';
-import Module from '../../../lib/Module.js';
-import { GraphState } from '../../GraphDiagram/graph_util.js';
+import type Module from '../../../lib/Module.js';
+import type { GraphState } from '../../GraphDiagram/graph_util.js';
 
 export type PeerDependencyInfo = {
   name: string;

--- a/components/GraphPane/reports/reporters/licensesAll.tsx
+++ b/components/GraphPane/reports/reporters/licensesAll.tsx
@@ -2,8 +2,8 @@ import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
 import { LICENSES } from '../../../../lib/licenses.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { LicenseAnalysisState } from '../analyzeLicenses.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { LicenseAnalysisState } from '../analyzeLicenses.js';
 import styles from './licensesAll.module.scss';
 
 export function licensesAll({

--- a/components/GraphPane/reports/reporters/licensesKeyword.tsx
+++ b/components/GraphPane/reports/reporters/licensesKeyword.tsx
@@ -1,9 +1,9 @@
 import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
-import { OSIKeyword } from '../../../../lib/licenses.js';
+import type { OSIKeyword } from '../../../../lib/licenses.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { LicenseAnalysisState } from '../analyzeLicenses.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { LicenseAnalysisState } from '../analyzeLicenses.js';
 import styles from './modulesAll.module.scss';
 
 export function licensesKeyword(keyword: OSIKeyword) {

--- a/components/GraphPane/reports/reporters/licensesMissing.tsx
+++ b/components/GraphPane/reports/reporters/licensesMissing.tsx
@@ -1,8 +1,8 @@
 import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { LicenseAnalysisState } from '../analyzeLicenses.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { LicenseAnalysisState } from '../analyzeLicenses.js';
 import styles from './licensesAll.module.scss';
 
 export function licensesMissing({

--- a/components/GraphPane/reports/reporters/maintainersAll.tsx
+++ b/components/GraphPane/reports/reporters/maintainersAll.tsx
@@ -2,8 +2,8 @@ import md5 from 'md5';
 import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { MaintainerAnalysisState } from '../analyzeMaintainers.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { MaintainerAnalysisState } from '../analyzeMaintainers.js';
 import styles from './maintainersAll.module.scss';
 
 export function maintainersAll({

--- a/components/GraphPane/reports/reporters/maintainersSolo.tsx
+++ b/components/GraphPane/reports/reporters/maintainersSolo.tsx
@@ -1,6 +1,6 @@
 import simplur from 'simplur';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { MaintainerAnalysisState } from '../analyzeMaintainers.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { MaintainerAnalysisState } from '../analyzeMaintainers.js';
 import { maintainersAll } from './maintainersAll.js';
 
 export function maintainersSolo({

--- a/components/GraphPane/reports/reporters/modulesAll.tsx
+++ b/components/GraphPane/reports/reporters/modulesAll.tsx
@@ -1,8 +1,8 @@
 import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { ModuleAnalysisState } from '../analyzeModules.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { ModuleAnalysisState } from '../analyzeModules.js';
 import styles from './modulesAll.module.scss';
 
 export function modulesAll({

--- a/components/GraphPane/reports/reporters/modulesDeprecated.tsx
+++ b/components/GraphPane/reports/reporters/modulesDeprecated.tsx
@@ -1,8 +1,8 @@
 import simplur from 'simplur';
 import { cn } from '../../../../lib/dom.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { ModuleAnalysisState } from '../analyzeModules.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { ModuleAnalysisState } from '../analyzeModules.js';
 import styles from './modulesDeprecated.module.scss';
 
 export function modulesDeprecated({

--- a/components/GraphPane/reports/reporters/modulesRepeated.tsx
+++ b/components/GraphPane/reports/reporters/modulesRepeated.tsx
@@ -1,8 +1,8 @@
 import simplur from 'simplur';
 import { getModuleKey } from '../../../../lib/module_util.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import { ModuleAnalysisState } from '../analyzeModules.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { ModuleAnalysisState } from '../analyzeModules.js';
 import styles from './modulesRepeated.module.scss';
 
 export function modulesRepeated({

--- a/components/GraphPane/reports/reporters/peerDependenciesAll.tsx
+++ b/components/GraphPane/reports/reporters/peerDependenciesAll.tsx
@@ -1,7 +1,7 @@
 import { cn } from '../../../../lib/dom.js';
 import { Selectable } from '../../../Selectable.js';
-import { RenderedAnalysis } from '../Analyzer.js';
-import {
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type {
   PeerDependenciesState,
   PeerDependencyInfo,
 } from '../analyzePeerDependencies.js';

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, SVGProps } from 'react';
+import React, { type HTMLProps, type SVGProps } from 'react';
 import { cn } from '../lib/dom.js';
 
 import './Icons.scss';

--- a/components/InfoPane/FileUploadControl.tsx
+++ b/components/InfoPane/FileUploadControl.tsx
@@ -36,10 +36,10 @@ export default function FileUploadControl(props: HTMLProps<HTMLLabelElement>) {
     const dt = ev.dataTransfer;
     if (!dt.items)
       return alert('Sorry, file dropping is not supported by this browser');
-    if (dt.items.length != 1) return alert('You must drop exactly one file');
+    if (dt.items.length !== 1) return alert('You must drop exactly one file');
 
     const item = dt.items[0];
-    if (item.type && item.type != 'application/json')
+    if (item.type && item.type !== 'application/json')
       return alert('File must have a ".json" extension');
 
     const file = item.getAsFile();

--- a/components/InfoPane/FileUploadControl.tsx
+++ b/components/InfoPane/FileUploadControl.tsx
@@ -1,5 +1,5 @@
-import { PackageJSON, PackumentVersion } from '@npm/types';
-import React, { HTMLProps } from 'react';
+import type { PackageJSON, PackumentVersion } from '@npm/types';
+import React, { type HTMLProps } from 'react';
 import {
   cacheLocalPackage,
   sanitizePackageKeys,

--- a/components/InfoPane/InfoPane.tsx
+++ b/components/InfoPane/InfoPane.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { Pane } from '../Pane.js';
 import { QueryLink } from '../QueryLink.js';
 import FileUploadControl from './FileUploadControl.js';

--- a/components/InfoPane/QueryInput.tsx
+++ b/components/InfoPane/QueryInput.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, useState } from 'react';
+import React, { type HTMLProps, useState } from 'react';
 import { useGlobalState } from '../../lib/GlobalStore.js';
 import { UNNAMED_PACKAGE } from '../../lib/constants.js';
 import { isDefined } from '../../lib/guards.js';

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps } from 'react';
+import type { HTMLProps } from 'react';
 import { useGlobalState } from '../lib/GlobalStore.js';
 import { queryModuleCache } from '../lib/ModuleCache.js';
 import { PARAM_HIDE } from '../lib/constants.js';

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -52,17 +52,17 @@ export default function Inspector(props: HTMLProps<HTMLDivElement>) {
   return (
     <div id="inspector" className={hide !== null ? '' : 'open'} {...props}>
       <div id="tabs">
-        <Tab active={pane == PANE.INFO} onClick={() => setPane(PANE.INFO)}>
+        <Tab active={pane === PANE.INFO} onClick={() => setPane(PANE.INFO)}>
           Start <kbd>/</kbd>
         </Tab>
-        <Tab active={pane == PANE.GRAPH} onClick={() => setPane(PANE.GRAPH)}>
+        <Tab active={pane === PANE.GRAPH} onClick={() => setPane(PANE.GRAPH)}>
           Graph
         </Tab>
-        <Tab active={pane == PANE.MODULE} onClick={() => setPane(PANE.MODULE)}>
+        <Tab active={pane === PANE.MODULE} onClick={() => setPane(PANE.MODULE)}>
           Module
         </Tab>
         <Tab
-          active={pane == PANE.ABOUT}
+          active={pane === PANE.ABOUT}
           onClick={() => setPane(PANE.ABOUT)}
           badge={newCommitsCount > 0}
         >

--- a/components/ModulePane/ModuleBundleSize.tsx
+++ b/components/ModulePane/ModuleBundleSize.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import Module from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 import fetchJSON from '../../lib/fetchJSON.js';
-import { BundlePhobiaData } from '../../lib/fetch_types.js';
+import type { BundlePhobiaData } from '../../lib/fetch_types.js';
 import { ExternalLink } from '../ExternalLink.js';
 import { ModuleBundleStats } from './ModuleBundleStats.js';
 import { ModuleTreeMap } from './ModuleTreeMap.js';

--- a/components/ModulePane/ModuleBundleStats.tsx
+++ b/components/ModulePane/ModuleBundleStats.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BundlePhobiaData } from '../../lib/fetch_types.js';
+import type { BundlePhobiaData } from '../../lib/fetch_types.js';
 import human from '../../lib/human.js';
 
 export function ModuleBundleStats({

--- a/components/ModulePane/ModuleNpmsIOScores.tsx
+++ b/components/ModulePane/ModuleNpmsIOScores.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import Module from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 import fetchJSON from '../../lib/fetchJSON.js';
-import { NPMSIOData } from '../../lib/fetch_types.js';
+import type { NPMSIOData } from '../../lib/fetch_types.js';
 import { ModuleScoreBar } from './ModuleScoreBar.js';
 
 export default function ModuleNpmsIOScores({ module }: { module: Module }) {

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -31,7 +31,7 @@ export default function ModulePane({
   const nSelected = selectedModules.size;
   const [graph] = useGlobalState('graph');
 
-  if (nSelected == 0) {
+  if (nSelected === 0) {
     return (
       <Pane
         style={{

--- a/components/ModulePane/ModulePane.tsx
+++ b/components/ModulePane/ModulePane.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import simplur from 'simplur';
 import { useGlobalState } from '../../lib/GlobalStore.js';
-import Module, { Maintainer } from '../../lib/Module.js';
+import type { Maintainer } from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 import { PARAM_COLORIZE } from '../../lib/constants.js';
 import human from '../../lib/human.js';
 import useHashParam from '../../lib/useHashParam.js';

--- a/components/ModulePane/ModuleTreeMap.tsx
+++ b/components/ModulePane/ModuleTreeMap.tsx
@@ -37,7 +37,7 @@ export function ModuleTreeMap({
 
     const root = stratify<BundlePhobiaData['dependencySizes'][number]>()
       .id(d => d.name)
-      .parentId(node => (node.name == '__root' ? '' : '__root'))(nodes)
+      .parentId(node => (node.name === '__root' ? '' : '__root'))(nodes)
       .sum(d => (d.approximateSize * size) / sum)
       .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 

--- a/components/ModulePane/ModuleTreeMap.tsx
+++ b/components/ModulePane/ModuleTreeMap.tsx
@@ -1,7 +1,7 @@
-import { HierarchyRectangularNode, stratify, treemap } from 'd3-hierarchy';
+import { type HierarchyRectangularNode, stratify, treemap } from 'd3-hierarchy';
 import React, { useEffect, useState } from 'react';
 import { $ } from 'select-dom';
-import { BundlePhobiaData } from '../../lib/fetch_types.js';
+import type { BundlePhobiaData } from '../../lib/fetch_types.js';
 import human from '../../lib/human.js';
 
 import styles from './ModuleTreeMap.module.scss';

--- a/components/ModulePane/ModuleVersionInfo.tsx
+++ b/components/ModulePane/ModuleVersionInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { parse } from 'semver';
 import simplur from 'simplur';
-import Module from '../../lib/Module.js';
+import type Module from '../../lib/Module.js';
 
 import { cn } from '../../lib/dom.js';
 import './ModuleVersionInfo.scss';

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -39,7 +39,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
       ] as const;
     })
     // "0.0.0" isn't a valid version (e.g. you can't npm publish it)
-    .filter(([, { semver }]) => semver.version != '0.0.0')
+    .filter(([, { semver }]) => semver.version !== '0.0.0')
     .sort(([, a], [, b]) => {
       return a.time < b.time ? -1 : 0;
     });

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -1,7 +1,7 @@
-import { PackumentVersion } from '@npm/types';
-import Module from '../../lib/Module.js';
+import type { PackumentVersion } from '@npm/types';
+import type Module from '../../lib/Module.js';
 
-import { SemVer, parse } from 'semver';
+import { type SemVer, parse } from 'semver';
 import { cn } from '../../lib/dom.js';
 import useMeasure from '../../lib/useMeasure.js';
 import { Section } from '../Section.js';

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -1,7 +1,7 @@
 import type { PackumentVersion } from '@npm/types';
+import { type SemVer, parse } from 'semver';
 import type Module from '../../lib/Module.js';
 
-import { type SemVer, parse } from 'semver';
 import { cn } from '../../lib/dom.js';
 import useMeasure from '../../lib/useMeasure.js';
 import { Section } from '../Section.js';

--- a/components/Pane.tsx
+++ b/components/Pane.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 
 export function Pane({ children, ...props }: HTMLProps<HTMLDivElement>) {
   return (

--- a/components/PieGraph.tsx
+++ b/components/PieGraph.tsx
@@ -2,8 +2,8 @@ import { quantize } from 'd3-interpolate';
 import { scaleOrdinal } from 'd3-scale';
 import { interpolateSpectral } from 'd3-scale-chromatic';
 import { select } from 'd3-selection';
-import { PieArcDatum, arc, pie } from 'd3-shape';
-import React, { HTMLProps, useEffect, useRef } from 'react';
+import { type PieArcDatum, arc, pie } from 'd3-shape';
+import React, { type HTMLProps, useEffect, useRef } from 'react';
 
 type PieDatum = [string, number];
 

--- a/components/QueryLink.tsx
+++ b/components/QueryLink.tsx
@@ -1,5 +1,5 @@
 import filterAlteredClicks from 'filter-altered-clicks';
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { useGlobalState } from '../lib/GlobalStore.js';
 import { PARAM_QUERY } from '../lib/constants.js';
 import { urlPatch } from '../lib/url_util.js';

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,4 +1,4 @@
-import { HTMLProps } from 'react';
+import type { HTMLProps } from 'react';
 import { cn } from '../lib/dom.js';
 
 import styles from './Section.module.scss';

--- a/components/Selectable.tsx
+++ b/components/Selectable.tsx
@@ -1,5 +1,5 @@
-import { HTMLProps } from 'react';
-import { QueryType } from '../lib/ModuleCache.js';
+import type { HTMLProps } from 'react';
+import type { QueryType } from '../lib/ModuleCache.js';
 import useGraphSelection from '../lib/useGraphSelection.js';
 
 import { cn } from '../lib/dom.js';

--- a/components/Tab.tsx
+++ b/components/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { cn } from '../lib/dom.js';
 import './Tab.scss';
 

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -1,6 +1,6 @@
 import md5 from 'md5';
-import React, { HTMLProps } from 'react';
-import { QueryType } from '../lib/ModuleCache.js';
+import React, { type HTMLProps } from 'react';
+import type { QueryType } from '../lib/ModuleCache.js';
 import { cn } from '../lib/dom.js';
 import useGraphSelection from '../lib/useGraphSelection.js';
 

--- a/components/Tags.tsx
+++ b/components/Tags.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 
 export function Tags({ children, style, ...props }: HTMLProps<HTMLDivElement>) {
   return (

--- a/components/Toggle.tsx
+++ b/components/Toggle.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { type HTMLProps } from 'react';
 import { cn } from '../lib/dom.js';
 import './Toggle.scss';
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,32 +1,38 @@
 import antfu from '@antfu/eslint-config';
 
-export default antfu({
-  rules: {
-    eqeqeq: 'off',
-    'no-alert': 'off',
-    'no-console': 'off',
-    'antfu/if-newline': 'off',
-    'import/order': 'off',
-    'style/arrow-parens': 'off',
-    'style/brace-style': 'off',
-    'style/indent-binary-ops': 'off',
-    'style/indent': 'off',
-    'style/member-delimiter-style': 'off',
-    'style/multiline-ternary': 'off',
-    'style/operator-linebreak': 'off',
-    'style/quote-props': 'off',
-    'style/quotes': 'off',
-    'style/semi': 'off',
-    'style/type-generic-spacing': 'off',
-    'ts/consistent-type-definitions': ['error', 'type'],
+export default antfu(
+  {
+    rules: {
+      eqeqeq: 'off',
+      'no-alert': 'off',
+      'no-console': 'off',
+      'antfu/if-newline': 'off',
+      'import/order': 'off',
+      'style/indent-binary-ops': 'off',
+      'ts/consistent-type-definitions': ['error', 'type'],
 
-    // Prettier conflicts
-    'style/jsx-one-expression-per-line': 'off',
+      // Prettier conflicts
+      'style/arrow-parens': 'off',
+      'style/brace-style': 'off',
+      'style/indent': 'off',
+      'style/jsx-one-expression-per-line': 'off',
+      'style/member-delimiter-style': 'off',
+      'style/multiline-ternary': 'off',
+      'style/operator-linebreak': 'off',
+      'style/quote-props': 'off',
+      'style/quotes': 'off',
+      'style/semi': 'off',
+      'style/type-generic-spacing': 'off',
+    },
   },
-}, {
-  // https://github.com/antfu/eslint-config/issues/570
-  files: ['**/*.ts', '**/*.tsx'],
-  rules: {
-    'ts/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
+  {
+    // https://github.com/antfu/eslint-config/issues/570
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {
+      'ts/consistent-type-imports': [
+        'error',
+        { fixStyle: 'inline-type-imports' },
+      ],
+    },
   },
-});
+);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,6 @@ export default antfu(
       'no-alert': 'off',
       'no-console': 'off',
       'antfu/if-newline': 'off',
-      'import/order': 'off',
       'style/indent-binary-ops': 'off',
       'ts/consistent-type-definitions': ['error', 'type'],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,6 @@ import antfu from '@antfu/eslint-config';
 export default antfu(
   {
     rules: {
-      eqeqeq: 'off',
       'no-alert': 'off',
       'no-console': 'off',
       'antfu/if-newline': 'off',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,10 +18,15 @@ export default antfu({
     'style/quotes': 'off',
     'style/semi': 'off',
     'style/type-generic-spacing': 'off',
-    'ts/consistent-type-imports': 'off',
     'ts/consistent-type-definitions': ['error', 'type'],
 
     // Prettier conflicts
     'style/jsx-one-expression-per-line': 'off',
+  },
+}, {
+  // https://github.com/antfu/eslint-config/issues/570
+  files: ['**/*.ts', '**/*.tsx'],
+  rules: {
+    'ts/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
   },
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,6 @@ export default antfu({
     'style/brace-style': 'off',
     'style/indent-binary-ops': 'off',
     'style/indent': 'off',
-    'style/jsx-one-expression-per-line': 'off',
     'style/member-delimiter-style': 'off',
     'style/multiline-ternary': 'off',
     'style/operator-linebreak': 'off',
@@ -21,5 +20,8 @@ export default antfu({
     'style/type-generic-spacing': 'off',
     'ts/consistent-type-imports': 'off',
     'ts/consistent-type-definitions': ['error', 'type'],
+
+    // Prettier conflicts
+    'style/jsx-one-expression-per-line': 'off',
   },
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,36 +1,33 @@
 import antfu from '@antfu/eslint-config';
 
-export default antfu(
-  {
-    rules: {
-      'no-alert': 'off',
-      'no-console': 'off',
-      'antfu/if-newline': 'off',
-      'style/indent-binary-ops': 'off',
-      'ts/consistent-type-definitions': ['error', 'type'],
+export default antfu({
+  rules: {
+    'no-alert': 'off',
+    'no-console': 'off',
+    'antfu/if-newline': 'off',
+    'style/indent-binary-ops': 'off',
+    'ts/consistent-type-definitions': ['error', 'type'],
 
-      // Prettier conflicts
-      'style/arrow-parens': 'off',
-      'style/brace-style': 'off',
-      'style/indent': 'off',
-      'style/jsx-one-expression-per-line': 'off',
-      'style/member-delimiter-style': 'off',
-      'style/multiline-ternary': 'off',
-      'style/operator-linebreak': 'off',
-      'style/quote-props': 'off',
-      'style/quotes': 'off',
-      'style/semi': 'off',
-      'style/type-generic-spacing': 'off',
-    },
+    // Prettier conflicts
+    'style/arrow-parens': 'off',
+    'style/brace-style': 'off',
+    'style/indent': 'off',
+    'style/jsx-one-expression-per-line': 'off',
+    'style/member-delimiter-style': 'off',
+    'style/multiline-ternary': 'off',
+    'style/operator-linebreak': 'off',
+    'style/quote-props': 'off',
+    'style/quotes': 'off',
+    'style/semi': 'off',
+    'style/type-generic-spacing': 'off',
   },
-  {
-    // https://github.com/antfu/eslint-config/issues/570
-    files: ['**/*.ts', '**/*.tsx'],
-    rules: {
+  typescript: {
+    overrides: {
+      // https://github.com/antfu/eslint-config/issues/570
       'ts/consistent-type-imports': [
         'error',
         { fixStyle: 'inline-type-imports' },
       ],
     },
   },
-);
+});

--- a/lib/GlobalStore.tsx
+++ b/lib/GlobalStore.tsx
@@ -1,8 +1,8 @@
 import { useSyncExternalStore } from 'react';
-import { GraphState } from '../components/GraphDiagram/graph_util.js';
+import type { GraphState } from '../components/GraphDiagram/graph_util.js';
 import { PANE } from '../components/Inspector.js';
-import Module from './Module.js';
-import { GithubCommit } from './fetch_types.js';
+import type Module from './Module.js';
+import type { GithubCommit } from './fetch_types.js';
 import { hashGet, searchGet } from './url_util.js';
 
 type GlobalState = {

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -1,4 +1,4 @@
-import { Packument, PackumentVersion } from '@npm/types';
+import type { Packument, PackumentVersion } from '@npm/types';
 import { isDefined } from './guards.js';
 import {
   getModuleKey,

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -1,4 +1,4 @@
-import { PackageJSON, Packument, PackumentVersion } from '@npm/types';
+import type { PackageJSON, Packument, PackumentVersion } from '@npm/types';
 import { gt, satisfies } from 'semver';
 import HttpError from './HttpError.js';
 import Module from './Module.js';
@@ -8,7 +8,7 @@ import {
   getNPMPackument,
 } from './PackumentCache.js';
 import PromiseWithResolvers, {
-  PromiseWithResolversType,
+  type PromiseWithResolversType,
 } from './PromiseWithResolvers.js';
 import { PARAM_PACKAGES } from './constants.js';
 import fetchJSON from './fetchJSON.js';

--- a/lib/PackumentCache.ts
+++ b/lib/PackumentCache.ts
@@ -1,7 +1,7 @@
-import { Packument } from '@npm/types';
+import type { Packument } from '@npm/types';
 import { REGISTRY_BASE_URL } from './ModuleCache.js';
 import PromiseWithResolvers, {
-  PromiseWithResolversType,
+  type PromiseWithResolversType,
 } from './PromiseWithResolvers.js';
 import fetchJSON from './fetchJSON.js';
 

--- a/lib/fetchJSON.ts
+++ b/lib/fetchJSON.ts
@@ -1,5 +1,5 @@
 import HttpError from './HttpError.js';
-import LoadActivity from './LoadActivity.js';
+import type LoadActivity from './LoadActivity.js';
 
 const requestCache = new Map<string, Promise<unknown>>();
 

--- a/lib/human.ts
+++ b/lib/human.ts
@@ -15,7 +15,7 @@ const UNITS: [number, string][] = [
 ];
 
 export default function human(v: number, suffix = '', sig = 0) {
-  const base = suffix == 'B' ? 1024 : 1000;
+  const base = suffix === 'B' ? 1024 : 1000;
   const { log10, floor, round } = Math;
   let exp = floor(log10(v) / log10(base));
   const unit = UNITS.find(([n]) => n <= exp);

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -3,6 +3,7 @@ import './bugsnag.js'; // Initialize ASAP!
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { $ } from 'select-dom';
 import App, { setActivityForApp } from '../components/App/App.js';
 import { Unsupported } from '../components/Unsupported.js';
 import { DiagramTitle } from './DiagramTitle.js';
@@ -11,7 +12,6 @@ import { syncPackagesHash } from './ModuleCache.js';
 import { setActivityForRequestCache } from './fetchJSON.js';
 import { flash } from './flash.js';
 import { fetchCommits } from './useCommits.js';
-import { $ } from 'select-dom';
 
 // Various features we depend on that have triggered bugsnag errors in the past
 function detectFeatures() {

--- a/lib/module_util.ts
+++ b/lib/module_util.ts
@@ -1,5 +1,5 @@
-import { PackumentVersion } from '@npm/types';
-import { Dependencies } from './Module.js';
+import type { PackumentVersion } from '@npm/types';
+import type { Dependencies } from './Module.js';
 
 export function isHttpModule(moduleKey: string) {
   return /^https?:\/\//.test(moduleKey);

--- a/lib/useCommits.ts
+++ b/lib/useCommits.ts
@@ -1,6 +1,6 @@
 import { setGlobalState, useGlobalState } from './GlobalStore.js';
 import fetchJSON from './fetchJSON.js';
-import { GithubCommit } from './fetch_types.js';
+import type { GithubCommit } from './fetch_types.js';
 
 export async function fetchCommits() {
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);

--- a/lib/useGraphSelection.ts
+++ b/lib/useGraphSelection.ts
@@ -1,4 +1,4 @@
-import { QueryType } from './ModuleCache.js';
+import type { QueryType } from './ModuleCache.js';
 import { PARAM_SELECTION } from './constants.js';
 import useHashParam from './useHashParam.js';
 


### PR DESCRIPTION
- Continues #262 

This PR:

- Enables import rules and applies their autofixes (`type` keyword, import order)
- Organizes config to highlight prettier incompatibilities
- _Manually_ applies `eqeqeq` fixes (about 15 replacements)

I also wanted to include new React rules but the PR has a bunch of autofixes already, those would get lost.