### PR TITLE
fix: use packument maintainers if available, fixes #261

### DIFF
--- a/components/GraphPane/reports/analyzeMaintainers.tsx
+++ b/components/GraphPane/reports/analyzeMaintainers.tsx
@@ -55,8 +55,9 @@ export function analyzeMaintainers({
     for (const m of maintainers) {
       const maintainer = normalizeMaintainer(m);
 
-      // Combine information the maintainer across multiple modules (increases
-      // the odds of us having an email to generate gravatar image from)
+      // Combine information maintainer info from across multiple modules
+      // (increases the odds of us having an email to generate gravatar image
+      // from)
       if (maintainer.email && maintainer.name) {
         emailByMaintainer.set(maintainer.name, maintainer.email);
       }

--- a/lib/Module.ts
+++ b/lib/Module.ts
@@ -52,8 +52,11 @@ export default class Module {
   }
 
   get maintainers() {
-    const pkg = this.getLatestVersion() ?? this.package;
-    let maintainers = pkg.maintainers ?? [];
+    let maintainers =
+      this.packument?.maintainers ??
+      this.getLatestVersion()?.maintainers ??
+      this.package?.maintainers ??
+      [];
 
     if (!Array.isArray(maintainers)) {
       console.warn(


### PR DESCRIPTION
`maintainers`  detected in the following locations, with the following priority:
1. `packument#maintainers`
2. `package@latest`
3. `packages@<version>`