### PR TITLE
chore: fix title verification

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ name: PR
 on:
   pull_request:
     types:
+      - synchronize # GitHub requires this workflow to run on the latest commit
       - opened
       - edited
 


### PR DESCRIPTION
So I figured out why GitHub was stuck on "waiting for title workflow to be reported": 

When you set a workflow as "required", it has to run on the last commit. That's why it can be fixed by changing the title right before merge (I did so in the last PR I merged)

Note: right now the "title" flow is not required because of this issue. I'll restore it after this PR is merged 