### PR TITLE
fix: hide empty sections in Graph tab

### DIFF
--- a/components/GraphPane/GraphPane.scss
+++ b/components/GraphPane/GraphPane.scss
@@ -16,10 +16,8 @@
   margin-top: 1rem;
 }
 
-#report-section {
-  // Hide empty sections
-  h3:has(+ h3),
-  h3:last-child {
-    display: none;
-  }
+// Hide empty sections
+.report-section hr:nth-last-child(2),
+.report-section h3:nth-last-child(1) {
+  display: none;
 }

--- a/components/GraphPane/GraphPane.tsx
+++ b/components/GraphPane/GraphPane.tsx
@@ -29,6 +29,16 @@ import {
   peerDependenciesMissing,
 } from './reports/reporters/peerDependenciesAll.js';
 
+function ReportSection({ title, children }: { title: string; children: any }) {
+  return (
+    <div className="report-section">
+      <hr />
+      <h3>{title}</h3>
+      {children}
+    </div>
+  );
+}
+
 export default function GraphPane({
   graph,
   ...props
@@ -88,11 +98,7 @@ export default function GraphPane({
         )}
       </div>
 
-      <hr />
-
-      <div id="report-section">
-        <h3>Modules</h3>
-
+      <ReportSection title="Modules">
         <ReportItem data={moduleAnalysis} reporter={modulesAll} />
 
         <ReportItem data={moduleAnalysis} reporter={modulesRepeated}>
@@ -117,11 +123,9 @@ export default function GraphPane({
           data={peerDependencyAnalysis}
           reporter={peerDependenciesMissing}
         />
+      </ReportSection>
 
-        <hr />
-
-        <h3>Maintainers</h3>
-
+      <ReportSection title="Maintainers">
         <ReportItem data={maintainersAnalysis} reporter={maintainersAll} />
 
         <ReportItem data={maintainersAnalysis} reporter={maintainersSolo}>
@@ -132,11 +136,8 @@ export default function GraphPane({
           </ExternalLink>
           .
         </ReportItem>
-
-        <hr />
-
-        <h3>Licenses</h3>
-
+      </ReportSection>
+      <ReportSection title="Licenses">
         <ReportItem data={licensesAnalysis} reporter={licensesAll} />
 
         <ReportItem
@@ -173,7 +174,7 @@ export default function GraphPane({
           </ExternalLink>
           .
         </ReportItem>
-      </div>
+      </ReportSection>
     </Pane>
   );
 }


### PR DESCRIPTION
Reapplies 

- https://github.com/npmgraph/npmgraph/pull/252

After

- #271 