### PR TITLE
feat: extend instructions on Start tab

### DIFF
--- a/components/InfoPane/InfoPane.tsx
+++ b/components/InfoPane/InfoPane.tsx
@@ -7,24 +7,27 @@ import QueryInput from './QueryInput.js';
 export default function InfoPane(props: HTMLProps<HTMLDivElement>) {
   return (
     <Pane {...props}>
-      <h3>
-        NPM name(s) or <code>package.json</code> URL
-      </h3>
+      <h3>Generate npmgraph:</h3>
 
       <QueryInput />
 
-      <p>
-        For example, try{' '}
-        <QueryLink query="express">&quot;express&quot;</QueryLink>,{' '}
-        <QueryLink query={['minimatch', 'cross-env', 'rimraf']}>
-          &quot;minimatch, cross-env, rimraf&quot;
-        </QueryLink>
-        , or{' '}
-        <QueryLink query="https://github.com/npmgraph/npmgraph/blob/main/package.json">
-          npmgraph's package.json on GitHub
-        </QueryLink>
-        .
-      </p>
+      <p>For example:</p>
+
+      <ul>
+        <li>
+          A npm module name: <QueryLink query={['express']} />
+        </li>
+        <li>
+          Multiple, versioned module names:{' '}
+          <QueryLink query={['cross-env@6', 'rimraf']} />
+        </li>
+        <li>
+          A URL to a{' '}
+          <QueryLink query="https://github.com/npmgraph/npmgraph/blob/main/package.json">
+            package.json file
+          </QueryLink>
+        </li>
+      </ul>
 
       <FileUploadControl />
     </Pane>

--- a/components/InfoPane/QueryInput.tsx
+++ b/components/InfoPane/QueryInput.tsx
@@ -46,6 +46,7 @@ export default function QueryInput(props: HTMLProps<HTMLInputElement>) {
       <input
         type="text"
         id="search-field"
+        placeholder="Search…"
         value={value}
         onKeyDown={handleKeyDown}
         onChange={e => setValue(e.target.value)}

--- a/components/Inspector.scss
+++ b/components/Inspector.scss
@@ -41,6 +41,11 @@
       }
     }
   }
+
+  ul {
+    margin-top: 0;
+    padding-inline-start: 1em;
+  }
 }
 
 label {

--- a/components/QueryLink.tsx
+++ b/components/QueryLink.tsx
@@ -27,7 +27,7 @@ export function QueryLink({
   if (!children) {
     return (
       <a href={url.href} onClick={filterAlteredClicks(onClick)} {...props}>
-        {queries.join(',')}
+        {queries.join(', ')}
       </a>
     );
   }


### PR DESCRIPTION
- Extracted unrelated style changes from https://github.com/npmgraph/npmgraph/pull/258

This prepares the tab for:

- https://github.com/npmgraph/npmgraph/pull/258
- #240 
- https://github.com/npmgraph/npmgraph/issues/277
- #276 



<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td><img width="426" alt="Screenshot" src="https://github.com/user-attachments/assets/a9f92dbe-041d-44db-b987-22bd69c52406">
	<td><img width="426" alt="Screenshot 16" src="https://github.com/user-attachments/assets/df1596e5-bf4a-40e8-a014-1272adcbc86e">
</table>