### PR TITLE
feat: add og:image

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
       content="visualize, visualization, graph, npm, npm modules, npm graph, npm licenses"
     />
 
+    <meta property="og:image" content="https://github.com/user-attachments/assets/7b1414d8-a6fd-4d00-8b49-ed490b077b01" />
+
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <link
       href="https://fonts.googleapis.com/css?family=Roboto+Condensed:400,700"

--- a/index.html
+++ b/index.html
@@ -32,7 +32,10 @@
       content="visualize, visualization, graph, npm, npm modules, npm graph, npm licenses"
     />
 
-    <meta property="og:image" content="https://github.com/user-attachments/assets/7b1414d8-a6fd-4d00-8b49-ed490b077b01" />
+    <meta
+      property="og:image"
+      content="https://github.com/user-attachments/assets/7b1414d8-a6fd-4d00-8b49-ed490b077b01"
+    />
 
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <link

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
       property="og:image"
       content="https://github.com/user-attachments/assets/7b1414d8-a6fd-4d00-8b49-ed490b077b01"
     />
+    <meta name="twitter:card" content="summary_large_image" />
 
     <link rel="icon" type="image/png" href="/images/favicon.png" />
     <link


### PR DESCRIPTION
- Mentioned in https://github.com/npmgraph/npmgraph/pull/285


It would be nice to use https://vercel.com/docs/functions/og-image-generation to create a custom image depending on the input, but it's low priority. I'd be more interested in changing the `title` depending on the `q` instead

![Screen Shot 2024-08-10 at 12 30 29](https://github.com/user-attachments/assets/7b1414d8-a6fd-4d00-8b49-ed490b077b01)
