### PR TITLE
feat: improve intro colors

### DIFF
--- a/components/Intro.module.scss
+++ b/components/Intro.module.scss
@@ -4,13 +4,14 @@
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  background: radial-gradient(
-    light-dark(var(--bg1), var(--bg0)),
-    var(--bg-root)
-  );
+  background: radial-gradient(var(--bg-root), color-mix(in lab, var(--accent) 10%, var(--bg-root)));
   padding: 1em;
   width: 100%;
   height: 100svh;
+
+  @media (prefers-color-scheme: dark) {
+    background: radial-gradient(var(--bg0), var(--bg-root));
+  }
 
   h1 {
     margin-block: 0;

--- a/components/Intro.module.scss
+++ b/components/Intro.module.scss
@@ -4,7 +4,10 @@
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  background: radial-gradient(var(--bg-root), color-mix(in lab, var(--accent) 10%, var(--bg-root)));
+  background: radial-gradient(
+    var(--bg-root),
+    color-mix(in lab, var(--accent) 10%, var(--bg-root))
+  );
   padding: 1em;
   width: 100%;
   height: 100svh;


### PR DESCRIPTION
I didn't really like the light mode radial gradient background colors
<table>
<tr>
	<th>Before
	<th>After
<tr>
<td>

![Screen Shot 2024-08-23 at 11 20 34 Medium](https://github.com/user-attachments/assets/8add5436-aea6-4dba-91dd-9b3e5b814493)

<td>


![Screen Shot 2024-08-23 at 11 20 06 Medium](https://github.com/user-attachments/assets/38a3c775-4c58-4ece-bbf5-dfc16094edde)

</table>

## Dark (unchanged)

![Screen Shot 2024-08-23 at 11 20 20 Medium](https://github.com/user-attachments/assets/f7803145-a31d-4869-9303-8b722c53bc22)

