### PR TITLE
fix: check for empty timeline in ReleaseTimeline component

### DIFF
--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -44,6 +44,9 @@ export function ReleaseTimeline({ module }: { module: Module }) {
       return a.time < b.time ? -1 : 0;
     });
 
+  // No releases to display?
+  if (byTime.length === 0) return;
+
   const majorMax = byTime.reduce(
     (acc, [, v]) => Math.max(acc, v.semver.major),
     byTime[0][1].semver.major,


### PR DESCRIPTION
Fixes this error:
https://npmgraph.js.org/?q=react-core#select=exact%3Areact-core%400.0.0

![CleanShot 2024-09-15 at 10 10 35@2x](https://github.com/user-attachments/assets/e4f8db8a-6f9f-409a-b149-69a00be70bc0)

Fixed version: https://npmgraph-git-emptyreleasetimeline-broofas-projects.vercel.app/?q=react-core#select=exact%3Areact-core%400.0.0