### PR TITLE
chore: move gtag code to HEAD

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,21 @@
 
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-0FPWJCJM5R"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-0FPWJCJM5R');
+    </script>
+
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta


### PR DESCRIPTION
Google wants the gtag snippet immediately after the opening HEAD token.