### PR TITLE
fix: correct downstream unpacked size calculation

### DIFF
--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -142,9 +142,10 @@ export async function getGraphForQuery(
         const downstreamModule = await getModule(getModuleKey(name, version));
 
         const moduleInfo = await _visit(downstreamModule, level + 1);
+        if (!moduleInfo) return;
 
-        moduleInfo?.upstream.add({ module, type });
-        info?.downstream.add({ module: downstreamModule, type });
+        moduleInfo.upstream.add({ module, type });
+        info.downstream.add({ module: moduleInfo.module, type });
       }),
     );
 
@@ -278,11 +279,12 @@ export function foreachUpstream(
   callback: (module: Module) => void,
   seen: Set<Module> = new Set(),
 ) {
-  const info = graph.moduleInfos.get(module.key);
-  if (!info || seen.has(module)) return;
   seen.add(module);
+  const info = graph.moduleInfos.get(module.key);
+  if (!info) return;
 
   for (const { module } of info.upstream) {
+    if (seen.has(module)) continue;
     callback(module);
     foreachUpstream(module, graph, callback, seen);
   }
@@ -294,11 +296,12 @@ export function foreachDownstream(
   callback: (module: Module) => void,
   seen: Set<Module> = new Set(),
 ) {
-  const info = graph.moduleInfos.get(module.key);
-  if (!info || seen.has(module)) return;
   seen.add(module);
+  const info = graph.moduleInfos.get(module.key);
+  if (!info) return;
 
   for (const { module } of info.downstream) {
+    if (seen.has(module)) continue;
     callback(module);
     foreachDownstream(module, graph, callback, seen);
   }

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -142,10 +142,8 @@ export async function getGraphForQuery(
         const downstreamModule = await getModule(getModuleKey(name, version));
 
         const moduleInfo = await _visit(downstreamModule, level + 1);
-        if (!moduleInfo) return;
-
-        moduleInfo.upstream.add({ module, type });
-        info.downstream.add({ module: moduleInfo.module, type });
+        moduleInfo?.upstream.add({ module, type });
+        info.downstream.add({ module: downstreamModule, type });
       }),
     );
 

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -143,7 +143,7 @@ export async function getGraphForQuery(
 
         const moduleInfo = await _visit(downstreamModule, level + 1);
         moduleInfo?.upstream.add({ module, type });
-        info.downstream.add({ module: downstreamModule, type });
+        info?.downstream.add({ module: downstreamModule, type });
       }),
     );
 

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -273,37 +273,20 @@ export function composeDOT({
     .join('\n');
 }
 
-export function foreachUpstream(
-  module: Module,
-  graph: GraphState,
-  callback: (module: Module) => void,
-  seen: Set<Module> = new Set(),
-) {
-  seen.add(module);
-  const info = graph.moduleInfos.get(module.key);
-  if (!info) return;
-
-  for (const { module } of info.upstream) {
-    if (seen.has(module)) continue;
-    callback(module);
-    foreachUpstream(module, graph, callback, seen);
-  }
-}
-
 export function foreachDownstream(
   module: Module,
   graph: GraphState,
   callback: (module: Module) => void,
   seen: Set<Module> = new Set(),
 ) {
-  seen.add(module);
   const info = graph.moduleInfos.get(module.key);
   if (!info) return;
+  seen.add(module);
 
-  for (const { module } of info.downstream) {
-    if (seen.has(module)) continue;
-    callback(module);
-    foreachDownstream(module, graph, callback, seen);
+  for (const { module: downstreamModule } of info.downstream) {
+    if (seen.has(downstreamModule)) continue;
+    callback(downstreamModule);
+    foreachDownstream(downstreamModule, graph, callback, seen);
   }
 }
 

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -143,7 +143,7 @@ export async function getGraphForQuery(
 
         const moduleInfo = await _visit(downstreamModule, level + 1);
         moduleInfo?.upstream.add({ module, type });
-        info?.downstream.add({ module: downstreamModule, type });
+        info.downstream.add({ module: downstreamModule, type });
       }),
     );
 

--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -271,20 +271,21 @@ export function composeDOT({
     .join('\n');
 }
 
+// Invoke callback once for each [unique] downstream module
 export function foreachDownstream(
   module: Module,
   graph: GraphState,
   callback: (module: Module) => void,
-  seen: Set<Module> = new Set(),
+  _seen: Set<Module> = new Set(),
 ) {
   const info = graph.moduleInfos.get(module.key);
   if (!info) return;
-  seen.add(module);
 
   for (const { module: downstreamModule } of info.downstream) {
-    if (seen.has(downstreamModule)) continue;
+    if (_seen.has(downstreamModule)) continue;
+    _seen.add(downstreamModule);
     callback(downstreamModule);
-    foreachDownstream(downstreamModule, graph, callback, seen);
+    foreachDownstream(downstreamModule, graph, callback, _seen);
   }
 }
 

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -61,7 +61,7 @@ function newCachedModule(...args: ConstructorParameters<typeof Module>) {
   if (cachedEntry) {
     return cachedEntry.promise;
   }
-console.log('NEW MODULE', moduleKey, pv.name, pv.version);
+
   // Create cache entry ASAP
   const cacheEntry = PromiseWithResolvers() as ModuleCacheEntry;
   moduleCache.set(moduleKey, cacheEntry);

--- a/lib/ModuleCache.ts
+++ b/lib/ModuleCache.ts
@@ -261,7 +261,6 @@ export function cacheLocalPackage(pkg: PackumentVersion) {
 
   // Add version to packument
   packument.versions[pkg.version] = pkg;
-console.log('NEW MODULE2', pkg.name, pkg.version, packument.versions[pkg.version]);
 
   const module = new Module(pkg);
 


### PR DESCRIPTION
TLDR: Shared dependencies were calculated twice for `Unpacked Size (module + dependencies):`. This PR fixes it to count once.

## Issue description

I was checking https://npmgraph.js.org/?q=magicast and I noticed that the `Unpacked Size (module + dependencies):` for `magicast` (root) isn't exactly accurate if you manually check the size of its dependencies.

It has a unique shared `@babel/types` dependency like this:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/0a509a9a-47b9-4a5f-a7c5-4065a4ba03c8" />

Before,`@babel/types` was accounted twice. Incorrectly totalling 8MB for `magicast`. This PR fixes to only account once with the new correct total being 5MB.