### PR TITLE
fix: detect and display dual-module support in colorizer

### DIFF
--- a/components/GraphPane/colorizers/BusFactorColorizer.tsx
+++ b/components/GraphPane/colorizers/BusFactorColorizer.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import type Module from '../../../lib/Module.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 import { LegendColor } from './LegendColor.js';
+import type { SimpleColorizer } from './index.js';
 
 export default {
   title: 'Maintainer Count',
@@ -22,4 +22,4 @@ export default {
     const bus = Math.min(module.maintainers.length, 4);
     return COLORIZE_COLORS[Math.max(0, bus - 1)];
   },
-};
+} as SimpleColorizer;

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -17,16 +17,20 @@ export default {
         <LegendColor color={COLORIZE_MODULE_CJS}>CJS Only</LegendColor>
         <LegendColor color={COLORIZE_MODULE_DUAL}>CJS and ESM</LegendColor>
         <LegendColor color={COLORIZE_MODULE_ESM}>ESM Only</LegendColor>
-        <LegendColor color={COLORIZE_MODULE_TYPES}>TS Types</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_TYPES}>
+          TypeScript types
+        </LegendColor>
       </>
     );
   },
 
   async colorForModule(module: Module) {
     const pkgType = detectPackageType(module.package as PackageJSON);
+
     if (pkgType.esm && pkgType.cjs) {
       return COLORIZE_MODULE_DUAL;
     }
+
     if (pkgType.esm) {
       return COLORIZE_MODULE_ESM;
     }
@@ -41,12 +45,6 @@ export default {
   },
 };
 
-type PackageModuleType = {
-  esm: boolean;
-  cjs: boolean;
-  types: boolean;
-};
-
 // Package-type detection logic
 //
 // Logic to look at a PackageJSON object and determine if it is an ESM or CJS
@@ -54,6 +52,21 @@ type PackageModuleType = {
 //
 // Ref:
 // https://github.com/npmgraph/npmgraph/pull/326#issuecomment-2972640439
+
+type PackageModuleType = {
+  esm: boolean;
+  cjs: boolean;
+  types: boolean;
+};
+
+function isESMFile(file?: string) {
+  return file?.endsWith?.('.mjs') || file?.endsWith?.('.mts');
+}
+
+function isCJSFile(file?: string) {
+  return file?.endsWith?.('.cjs') || file?.endsWith?.('.cts');
+}
+
 function detectPackageType(pkg: PackageJSON) {
   // If the package name starts with @types/, then it's TS-types only
   if (pkg.name.startsWith?.('@types/')) {
@@ -72,8 +85,8 @@ function detectPackageType(pkg: PackageJSON) {
   };
 
   // Inspect package#main
-  if (pkg.main?.endsWith?.('.mjs')) pkgType.esm = true;
-  if (pkg.main?.endsWith?.('.cjs')) pkgType.cjs = true;
+  if (isESMFile(pkg.main)) pkgType.esm = true;
+  if (isCJSFile(pkg.main)) pkgType.cjs = true;
 
   // Inspect package#exports (recursively)
   return _detectExports(pkg.exports, pkgType);
@@ -81,25 +94,37 @@ function detectPackageType(pkg: PackageJSON) {
 
 // Loosely inspect package.json#exports for module type (recursive)
 function _detectExports(exports: unknown, pkgType: PackageModuleType) {
+  if (!exports) return pkgType;
+
+  // The presence of .mjs, .mts, .cjs, or .cts files is a strong indicator of
+  // the module type
+  if (typeof exports === 'string') {
+    if (isESMFile(exports)) pkgType.esm = true;
+    if (isCJSFile(exports)) pkgType.cjs = true;
+    return pkgType;
+  }
+
+  // Drill into array values
   if (Array.isArray(exports)) exports.some(v => _detectExports(v, pkgType));
 
-  if (exports && typeof exports === 'object') {
-    for (const [k, v] of Object.entries(exports)) {
-      if (k === 'import') {
-        pkgType.esm = true;
-      } else if (k === 'require') {
-        pkgType.cjs = true;
-      } else if (k === 'default') {
-        pkgType.esm = true;
-        pkgType.cjs = true;
-      }
+  if (typeof exports === 'object') {
+    const defaultVal = 'default' in exports && exports.default;
+    const importVal = 'import' in exports && exports.import;
+    const requireVal = 'require' in exports && exports.require;
 
+    // Infer dual support if there's an explicit import or require in
+    // combination with a default export
+    if (importVal || (defaultVal && requireVal)) pkgType.esm = true;
+    if (requireVal || (defaultVal && importVal)) pkgType.cjs = true;
+
+    // Walk through the exports object
+    for (const [k, v] of Object.entries(exports)) {
       if (typeof v === 'string') {
-        if (v?.endsWith('.mjs')) pkgType.esm = true;
-        if (v?.endsWith('.cjs')) pkgType.cjs = true;
-      } else {
         _detectExports(v, pkgType);
       }
+
+      // Recurse into "." exports
+      if (k === '.') _detectExports(v, pkgType);
     }
   }
 

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -37,7 +37,7 @@ export default {
 
 // Examine a package.json#exports object to see if it might have ESM exports
 function hasEsmExports(exports: unknown): boolean {
-  if (Array.isArray(exports)) return exports.some(e => hasEsmExports(e));
+  if (Array.isArray(exports)) return exports.some(hasEsmExports);
   if (!exports || typeof exports !== 'object') return false;
 
   for (const [k, v] of Object.entries(exports)) {
@@ -54,7 +54,7 @@ function hasEsmExports(exports: unknown): boolean {
 
 // Examine a package.json#exports object to see if it looks might have CJS exports
 function hasCjsExports(exports: unknown): boolean {
-  if (Array.isArray(exports)) return exports.some(e => hasCjsExports(e));
+  if (Array.isArray(exports)) return exports.some(hasCjsExports);
   if (!exports || typeof exports !== 'object') return false;
 
   for (const [k, v] of Object.entries(exports)) {

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -50,9 +50,6 @@ export default {
 
 // Package-type detection logic
 //
-// Logic to look at a PackageJSON object and determine if it is an ESM or CJS
-// package, with some other convenience logic thrown in for good measure.
-//
 // Ref:
 // https://github.com/npmgraph/npmgraph/pull/326#issuecomment-2972640439
 
@@ -71,7 +68,7 @@ function isCJSFile(file?: string) {
 }
 
 function detectPackageType(pkg: PackageJSON) {
-  // If the package name starts with @types/, then it's TS-types only
+  // @types/* packages are TS-types (not CJS or ESM)
   if (pkg.name.startsWith?.('@types/')) {
     return { esm: false, cjs: false, types: true };
   }

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -5,6 +5,7 @@ import { LegendColor } from './LegendColor.js';
 export const COLORIZE_MODULE_CJS = 'var(--bg-red)';
 export const COLORIZE_MODULE_DUAL = 'var(--bg-yellow)';
 export const COLORIZE_MODULE_ESM = 'var(--bg-green)';
+export const COLORIZE_MODULE_TYPES = 'var(--bg-blue)';
 
 export default {
   title: 'Module Type',
@@ -16,55 +17,91 @@ export default {
         <LegendColor color={COLORIZE_MODULE_CJS}>CJS Only</LegendColor>
         <LegendColor color={COLORIZE_MODULE_DUAL}>CJS and ESM</LegendColor>
         <LegendColor color={COLORIZE_MODULE_ESM}>ESM Only</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_TYPES}>TS Types</LegendColor>
       </>
     );
   },
 
   async colorForModule(module: Module) {
-    const pkg = module.package as PackageJSON;
-    const isEsm = pkg.type === 'module' || hasEsmExports(pkg.exports);
-    const isCjs = pkg.type !== 'module' || hasCjsExports(pkg.exports);
-    if (isEsm && isCjs) {
+    const pkgType = detectPackageType(module.package as PackageJSON);
+    if (pkgType.esm && pkgType.cjs) {
       return COLORIZE_MODULE_DUAL;
     }
-    if (isEsm) {
+    if (pkgType.esm) {
       return COLORIZE_MODULE_ESM;
     }
 
-    return COLORIZE_MODULE_CJS;
+    if (pkgType.cjs) {
+      return COLORIZE_MODULE_CJS;
+    }
+
+    if (pkgType.types) {
+      return COLORIZE_MODULE_TYPES;
+    }
   },
 };
 
-// Examine a package.json#exports object to see if it might have ESM exports
-function hasEsmExports(exports: unknown): boolean {
-  if (Array.isArray(exports)) return exports.some(hasEsmExports);
-  if (!exports || typeof exports !== 'object') return false;
+type PackageModuleType = {
+  esm: boolean;
+  cjs: boolean;
+  types: boolean;
+};
 
-  for (const [k, v] of Object.entries(exports)) {
-    if (k === 'import') return true;
-    if (typeof v === 'string') {
-      if (v?.endsWith('.mjs')) return true;
-    } else {
-      if (hasEsmExports(v)) return true;
-    }
+// Package-type detection logic
+//
+// Logic to look at a PackageJSON object and determine if it is an ESM or CJS
+// package, with some other convenience logic thrown in for good measure.
+//
+// Ref:
+// https://github.com/npmgraph/npmgraph/pull/326#issuecomment-2972640439
+function detectPackageType(pkg: PackageJSON) {
+  // If the package name starts with @types/, then it's TS-types only
+  if (pkg.name.startsWith?.('@types/')) {
+    return { esm: false, cjs: false, types: true };
   }
 
-  return false;
+  const pkgType: PackageModuleType = {
+    // If pkg#type is not set to 'module', assume it's CJS
+    cjs: pkg.type !== 'module',
+
+    // If pkg#type is set to 'module', then it's ESM
+    esm: pkg.type === 'module',
+
+    // If pkg#types is set, then TS types are available
+    types: pkg.types !== undefined,
+  };
+
+  // Inspect package#main
+  if (pkg.main?.endsWith?.('.mjs')) pkgType.esm = true;
+  if (pkg.main?.endsWith?.('.cjs')) pkgType.cjs = true;
+
+  // Inspect package#exports (recursively)
+  return _detectExports(pkg.exports, pkgType);
 }
 
-// Examine a package.json#exports object to see if it looks might have CJS exports
-function hasCjsExports(exports: unknown): boolean {
-  if (Array.isArray(exports)) return exports.some(hasCjsExports);
-  if (!exports || typeof exports !== 'object') return false;
+// Loosely inspect package.json#exports for module type (recursive)
+function _detectExports(exports: unknown, pkgType: PackageModuleType) {
+  if (Array.isArray(exports)) exports.some(v => _detectExports(v, pkgType));
 
-  for (const [k, v] of Object.entries(exports)) {
-    if (k === 'require') return true;
-    if (typeof v === 'string') {
-      if (v?.endsWith('.cjs')) return true;
-    } else {
-      if (hasCjsExports(v)) return true;
+  if (exports && typeof exports === 'object') {
+    for (const [k, v] of Object.entries(exports)) {
+      if (k === 'import') {
+        pkgType.esm = true;
+      } else if (k === 'require') {
+        pkgType.cjs = true;
+      } else if (k === 'default') {
+        pkgType.esm = true;
+        pkgType.cjs = true;
+      }
+
+      if (typeof v === 'string') {
+        if (v?.endsWith('.mjs')) pkgType.esm = true;
+        if (v?.endsWith('.cjs')) pkgType.cjs = true;
+      } else {
+        _detectExports(v, pkgType);
+      }
     }
   }
 
-  return false;
+  return pkgType;
 }

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -2,8 +2,9 @@ import type { PackageJSON } from '@npm/types';
 import type Module from '../../../lib/Module.js';
 import { LegendColor } from './LegendColor.js';
 
-export const COLORIZE_MODULE_CJS = 'var(--bg-orange)';
-export const COLORIZE_MODULE_ESM = 'var(--bg-blue)';
+export const COLORIZE_MODULE_CJS = 'var(--bg-red)';
+export const COLORIZE_MODULE_DUAL = 'var(--bg-yellow)';
+export const COLORIZE_MODULE_ESM = 'var(--bg-green)';
 
 export default {
   title: 'Module Type',
@@ -12,14 +13,58 @@ export default {
   legend() {
     return (
       <>
-        <LegendColor color={COLORIZE_MODULE_CJS}>CommonJS (CJS)</LegendColor>
-        <LegendColor color={COLORIZE_MODULE_ESM}>EcmaScript (ESM)</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_CJS}>CJS Only</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_DUAL}>CJS and ESM</LegendColor>
+        <LegendColor color={COLORIZE_MODULE_ESM}>ESM Only</LegendColor>
       </>
     );
   },
 
   async colorForModule(module: Module) {
     const pkg = module.package as PackageJSON;
-    return pkg.type === 'module' ? COLORIZE_MODULE_ESM : COLORIZE_MODULE_CJS;
+    const isEsm = pkg.type === 'module' || hasEsmExports(pkg.exports);
+    const isCjs = pkg.type !== 'module' || hasCjsExports(pkg.exports);
+    if (isEsm && isCjs) {
+      return COLORIZE_MODULE_DUAL;
+    }
+    if (isEsm) {
+      return COLORIZE_MODULE_ESM;
+    }
+
+    return COLORIZE_MODULE_CJS;
   },
 };
+
+// Examine a package.json#exports object to see if it might have ESM exports
+function hasEsmExports(exports: unknown): boolean {
+  if (Array.isArray(exports)) return exports.some(e => hasEsmExports(e));
+  if (!exports || typeof exports !== 'object') return false;
+
+  for (const [k, v] of Object.entries(exports)) {
+    if (k === 'import') return true;
+    if (typeof v === 'string') {
+      if (v?.endsWith('.mjs')) return true;
+    } else {
+      if (hasEsmExports(v)) return true;
+    }
+  }
+
+  return false;
+}
+
+// Examine a package.json#exports object to see if it looks might have CJS exports
+function hasCjsExports(exports: unknown): boolean {
+  if (Array.isArray(exports)) return exports.some(e => hasCjsExports(e));
+  if (!exports || typeof exports !== 'object') return false;
+
+  for (const [k, v] of Object.entries(exports)) {
+    if (k === 'require') return true;
+    if (typeof v === 'string') {
+      if (v?.endsWith('.cjs')) return true;
+    } else {
+      if (hasCjsExports(v)) return true;
+    }
+  }
+
+  return false;
+}

--- a/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
+++ b/components/GraphPane/colorizers/ModuleTypeColorizer.tsx
@@ -1,6 +1,7 @@
 import type { PackageJSON } from '@npm/types';
 import type Module from '../../../lib/Module.js';
 import { LegendColor } from './LegendColor.js';
+import type { SimpleColorizer } from './index.js';
 
 export const COLORIZE_MODULE_CJS = 'var(--bg-red)';
 export const COLORIZE_MODULE_DUAL = 'var(--bg-yellow)';
@@ -42,8 +43,10 @@ export default {
     if (pkgType.types) {
       return COLORIZE_MODULE_TYPES;
     }
+
+    return '';
   },
-};
+} as SimpleColorizer;
 
 // Package-type detection logic
 //

--- a/components/GraphPane/colorizers/OutdatedColorizer.tsx
+++ b/components/GraphPane/colorizers/OutdatedColorizer.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import { diff } from 'semver';
 import type Module from '../../../lib/Module.js';
 import { getNPMPackument } from '../../../lib/PackumentCache.js';
 import { COLORIZE_COLORS } from '../../../lib/constants.js';
 import { LegendColor } from './LegendColor.js';
+import type { SimpleColorizer } from './index.js';
 
 export default {
   title: 'Outdated Level',
@@ -48,4 +48,4 @@ export default {
         return '';
     }
   },
-};
+} as SimpleColorizer;


### PR DESCRIPTION
Fixes #325.

@SuperchupuDev: If you could do some testing for this, that would be helpful (see Vercel preview build link below).  The logic I've added for detecting ESM and CJS support is almost certainly imperfect.  It just walks the `package.json#exports` field looking for `import` or `require` fields, or paths with `.mjs` or `.cjs`.  I expect it's good enough to ship, but there's no real standard for how dual-module packages should be setup.  Thus, I'm sure there will be edge cases that aren't properly detected.

![CleanShot 2025-06-13 at 23 15 57@2x](https://github.com/user-attachments/assets/e754fd23-103f-488e-98d0-ba0853ca34d6)
