### PR TITLE
Colorspace

### DIFF
--- a/components/GraphDiagram/graph_util.ts
+++ b/components/GraphDiagram/graph_util.ts
@@ -358,8 +358,3 @@ export function gatherSelectionInfo(
     downstreamModuleKeys,
   };
 }
-
-// Use color-mix to blend two colors in HSL space
-export function hslFor(perc: number) {
-  return `hsl(${Math.round(perc * 120)}, 80%, var(--bg-L))`;
-}

--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -1,5 +1,6 @@
 import type Module from '../../../lib/Module.js';
 import PromiseWithResolvers from '../../../lib/PromiseWithResolvers.js';
+import { percent } from '../../../lib/dom.js';
 import fetchJSON from '../../../lib/fetchJSON.js';
 import type { NPMSIOData } from '../../../lib/fetch_types.js';
 import { flash } from '../../../lib/flash.js';
@@ -32,8 +33,7 @@ class NPMSColorizer implements BulkColorizer {
         <span
           style={{
             flexGrow: 1,
-            background:
-              `linear-gradient(90deg, ${scoreColor(0)} 0, ${scoreColor(1)} 100%)`,
+            background: `linear-gradient(in oklch increasing hue 90deg, ${scoreColor(0)} 0, ${scoreColor(1)} 100%)`,
           }}
         />
         <span>&nbsp;100%</span>
@@ -111,7 +111,7 @@ class NPMSColorizer implements BulkColorizer {
 }
 
 export function scoreColor(score: number) {
-  return `oklch(var(--bg-L) var(--bg-C) ${Math.round(20 + score * 130)})`;
+  return `color-mix(in oklch increasing hue, var(--bg-red), var(--bg-green) ${percent(score)})`;
 }
 
 export const NPMSOverallColorizer = new NPMSColorizer(

--- a/components/GraphPane/colorizers/NPMSColorizer.tsx
+++ b/components/GraphPane/colorizers/NPMSColorizer.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
 import type Module from '../../../lib/Module.js';
 import PromiseWithResolvers from '../../../lib/PromiseWithResolvers.js';
 import fetchJSON from '../../../lib/fetchJSON.js';
 import type { NPMSIOData } from '../../../lib/fetch_types.js';
 import { flash } from '../../../lib/flash.js';
-import { hslFor } from '../../GraphDiagram/graph_util.js';
 import type { BulkColorizer } from './index.js';
 
 // Max number of module names allowed per NPMS request
@@ -31,14 +29,13 @@ class NPMSColorizer implements BulkColorizer {
     return (
       <div style={{ display: 'flex' }}>
         <span>0%&nbsp;</span>
-        {Array.from({ length: 20 })
-          .fill(0)
-          .map((_, i) => (
-            <span
-              key={i}
-              style={{ flexGrow: '1', backgroundColor: hslFor(i / 19) }}
-            />
-          ))}
+        <span
+          style={{
+            flexGrow: 1,
+            background:
+              `linear-gradient(90deg, ${scoreColor(0)} 0, ${scoreColor(1)} 100%)`,
+          }}
+        />
         <span>&nbsp;100%</span>
       </div>
     );
@@ -92,16 +89,16 @@ class NPMSColorizer implements BulkColorizer {
       let color: string | undefined;
       switch (this.name) {
         case COLORIZE_OVERALL:
-          color = hslFor(score.final);
+          color = scoreColor(score.final);
           break;
         case COLORIZE_QUALITY:
-          color = hslFor(score.detail.quality);
+          color = scoreColor(score.detail.quality);
           break;
         case COLORIZE_POPULARITY:
-          color = hslFor(score.detail.popularity);
+          color = scoreColor(score.detail.popularity);
           break;
         case COLORIZE_MAINTENANCE:
-          color = hslFor(score.detail.maintenance);
+          color = scoreColor(score.detail.maintenance);
           break;
       }
       if (color) {
@@ -111,6 +108,10 @@ class NPMSColorizer implements BulkColorizer {
 
     return colors;
   }
+}
+
+export function scoreColor(score: number) {
+  return `oklch(var(--bg-L) var(--bg-C) ${Math.round(20 + score * 130)})`;
 }
 
 export const NPMSOverallColorizer = new NPMSColorizer(

--- a/components/Intro.module.scss
+++ b/components/Intro.module.scss
@@ -6,7 +6,7 @@
   box-sizing: border-box;
   background: radial-gradient(
     var(--bg-root),
-    color-mix(in lab, var(--accent) 10%, var(--bg-root))
+    color-mix(in oklch, var(--accent) 10%, var(--bg-root))
   );
   padding: 1em;
   width: 100%;

--- a/components/ModulePane/ModuleScoreBar.module.scss
+++ b/components/ModulePane/ModuleScoreBar.module.scss
@@ -7,7 +7,7 @@
   width: 200px;
 
   & > .inner {
-    color: var(--bg0);
+    color: var(--text);
     text-align: right;
   }
 }

--- a/components/ModulePane/ModuleScoreBar.tsx
+++ b/components/ModulePane/ModuleScoreBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { scoreColor } from '../GraphPane/colorizers/NPMSColorizer.js';
 import * as styles from './ModuleScoreBar.module.scss';
 
 export function ModuleScoreBar({
@@ -22,7 +23,7 @@ export function ModuleScoreBar({
           className={styles.inner}
           style={{
             width: perc,
-            backgroundColor: `hsl(${score * 120}, 50%, 50%)`,
+            backgroundColor: scoreColor(score),
             ...style,
           }}
         >

--- a/components/ModulePane/ModuleScoreBar.tsx
+++ b/components/ModulePane/ModuleScoreBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { percent } from '../../lib/dom.js';
 import { scoreColor } from '../GraphPane/colorizers/NPMSColorizer.js';
 import * as styles from './ModuleScoreBar.module.scss';
 
@@ -11,7 +12,7 @@ export function ModuleScoreBar({
   score: number;
   style?: React.CSSProperties;
 }) {
-  const perc = `${(score * 100).toFixed(0)}%`;
+  const perc = percent(score);
 
   return (
     <>
@@ -22,7 +23,7 @@ export function ModuleScoreBar({
         <div
           className={styles.inner}
           style={{
-            width: perc,
+            width: percent(score),
             backgroundColor: scoreColor(score),
             ...style,
           }}

--- a/components/ModulePane/ModuleTreeMap.tsx
+++ b/components/ModulePane/ModuleTreeMap.tsx
@@ -4,6 +4,7 @@ import { $ } from 'select-dom';
 import type { BundlePhobiaData } from '../../lib/fetch_types.js';
 import human from '../../lib/human.js';
 
+import { percent } from '../../lib/dom.js';
 import * as styles from './ModuleTreeMap.module.scss';
 
 export function ModuleTreeMap({
@@ -52,6 +53,8 @@ export function ModuleTreeMap({
       >;
       const size = human(d.value ?? 0, 'B');
       const frac = ((rd.x1 - rd.x0) * (rd.y1 - rd.y0)) / (w * h);
+      const backgroundColor = `color-mix(in oklch increasing hue, var(--bg-red), var(--bg-violet) ${percent(i / (a.length - 1))})`;
+
       return (
         <div
           key={d.data.name}
@@ -63,7 +66,7 @@ export function ModuleTreeMap({
             width: `${rd.x1 - rd.x0 - m}px`,
             height: `${rd.y1 - rd.y0 - m}px`,
             fontSize: `${65 + 70 * Math.sqrt(frac)}%`,
-            backgroundColor: `hsl(${30 + (i / a.length) * 300}, 50%, 50%)`,
+            backgroundColor,
           }}
         >
           {d.data.name} <span>{size}</span>

--- a/components/ModulePane/ModuleTreeMap.tsx
+++ b/components/ModulePane/ModuleTreeMap.tsx
@@ -63,7 +63,7 @@ export function ModuleTreeMap({
             width: `${rd.x1 - rd.x0 - m}px`,
             height: `${rd.y1 - rd.y0 - m}px`,
             fontSize: `${65 + 70 * Math.sqrt(frac)}%`,
-            backgroundColor: `hsl(${30 + (i / a.length) * 180}, 50%, 50%)`,
+            backgroundColor: `hsl(${30 + (i / a.length) * 300}, 50%, 50%)`,
           }}
         >
           {d.data.name} <span>{size}</span>

--- a/components/ModulePane/ReleaseTimeline.module.scss
+++ b/components/ModulePane/ReleaseTimeline.module.scss
@@ -1,7 +1,6 @@
 .root {
-  border: solid 1px var(--grey70);
-  border-radius: 0.3rem;
-  background-color: var(--grey90);
+  border: solid 1px var(--grey90);
+  background-color: var(--grey100);
 
   width: 100%;
   height: 8rem;
@@ -16,20 +15,22 @@
     display: inline-block;
     vertical-align: middle;
     border-radius: 50%;
-    background-color: red;
     width: 0.7em;
     height: 0.7em;
   }
   .dotKeyMajor {
-    background-color: var(--bg-red);
+    background-color: var(--grey100);
+    border: solid 1px var(--grey20);
     width: 1em;
     height: 1em;
   }
   .dotKeyMinor {
     background-color: var(--bg-orange);
+    width: 0.8em;
+    height: 0.8em;
   }
   .dotKeyPatch {
-    background-color: var(--bg-yellow);
+    background-color: var(--bg-green);
   }
   .dotKeyPrerelease {
     background-color: var(--bg-blue);
@@ -39,18 +40,30 @@
 svg {
   cursor: default;
 
+  .dot > text {
+    fill: var(--text);
+  }
+
   > .layer-grid {
-    stroke: var(--grey20);
+    stroke: var(--grey60);
   }
 
   .layer-major {
-    fill: var(--bg-red);
+    circle {
+      stroke: var(--grey20);
+      stroke-width: 0.1em;
+      fill: var(--grey100);
+    }
+    text {
+      fill: var(--text);
+    }
   }
+
   .layer-minor {
     fill: var(--bg-orange);
   }
   .layer-patch {
-    fill: var(--bg-yellow);
+    fill: var(--bg-green);
   }
   .layer-prerelease {
     fill: var(--bg-blue);

--- a/components/ModulePane/ReleaseTimeline.module.scss
+++ b/components/ModulePane/ReleaseTimeline.module.scss
@@ -19,8 +19,8 @@
     height: 0.7em;
   }
   .dotKeyMajor {
-    background-color: var(--grey100);
     border: solid 1px var(--grey20);
+    background-color: var(--grey100);
     width: 1em;
     height: 1em;
   }

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -137,7 +137,6 @@ export function ReleaseTimeline({ module }: { module: Module }) {
 
   const xpad = w * 0.1;
   const ypad = h * 0.1;
-  console.log('STYLES', styles);
   return (
     <Section title="Release Timeline">
       <svg

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -103,7 +103,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
       r *= 0.4;
     } else if (semver.minor) {
       layer = 'minor';
-      r *= 0.4;
+      r *= 0.5;
     } else if (semver.major) {
       layer = 'major';
 
@@ -116,7 +116,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
     }
 
     layers[layer].push(
-      <g key={`dot=${key}`} className="dot">
+      <g key={`dot=${key}`} className={styles.dot}>
         <title>{title}</title>
         <circle cx={x} cy={y} r={r} />
         {
@@ -125,13 +125,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
             <>
               <title>{title}</title>
 
-              <text
-                x={x}
-                y={y}
-                textAnchor="middle"
-                alignmentBaseline="middle"
-                fill="white"
-              >
+              <text x={x} y={y} textAnchor="middle" alignmentBaseline="central">
                 {semver.major}
               </text>
             </>
@@ -143,7 +137,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
 
   const xpad = w * 0.1;
   const ypad = h * 0.1;
-
+  console.log('STYLES', styles);
   return (
     <Section title="Release Timeline">
       <svg
@@ -153,6 +147,7 @@ export function ReleaseTimeline({ module }: { module: Module }) {
       >
         {Object.entries(layers).map(([k, layer]) => {
           return (
+            // @ts-expect-error scss imports aren't getting typed correctly
             <g key={`layer-${k}`} className={styles[`layer-${k}`]}>
               {layer}
             </g>

--- a/components/ModulePane/ReleaseTimeline.tsx
+++ b/components/ModulePane/ReleaseTimeline.tsx
@@ -146,7 +146,6 @@ export function ReleaseTimeline({ module }: { module: Module }) {
       >
         {Object.entries(layers).map(([k, layer]) => {
           return (
-            // @ts-expect-error scss imports aren't getting typed correctly
             <g key={`layer-${k}`} className={styles[`layer-${k}`]}>
               {layer}
             </g>

--- a/index.scss
+++ b/index.scss
@@ -5,7 +5,7 @@
   color-scheme: light dark;
 
   @for $i from 0 through 10 {
-    --grey#{($i) * 10}: hsl(0, 0%, #{$i * 10%});
+    --grey#{($i) * 10}: oklch(#{$i * 10%} 0 0);
   }
 
   --root-color: white; // Don't change, it's used to mix colors on light/dark schemes
@@ -37,37 +37,37 @@
   --bg0-shadow-color: color-mix(in hsl, var(--bg0) 90%, black);
 
   // Named stroke colors (for borders and lines that should contrast well with background colors)
-  --stroke-L: 40%;
-  --stroke-S: 100%;
-  --stroke-blue: hsl(180, var(--stroke-S), var(--stroke-L));
-  --stroke-orange: hsl(30, var(--stroke-S), var(--stroke-L));
-  --stroke-green: hsl(120, var(--stroke-S), var(--stroke-L));
-  --stroke-indigo: hsl(240, var(--stroke-S), var(--stroke-L));
-  --stroke-red: hsl(0, var(--stroke-S), var(--stroke-L));
-  --stroke-violet: hsl(300, var(--stroke-S), var(--stroke-L));
-  --stroke-yellow: hsl(60, var(--stroke-S), var(--stroke-L));
+  --stroke-L: 70%;
+  --stroke-C: 50%;
+  --stroke-red: oklch(var(--stroke-L) var(--stroke-C) 20);
+  --stroke-orange: oklch(var(--stroke-L) var(--stroke-C) 60);
+  --stroke-yellow: oklch(var(--stroke-L) var(--stroke-C) 90);
+  --stroke-green: oklch(var(--stroke-L) var(--stroke-C) 150);
+  --stroke-blue: oklch(var(--stroke-L) var(--stroke-C) 220);
+  --stroke-indigo: oklch(var(--stroke-L) var(--stroke-C) 250);
+  --stroke-violet: oklch(var(--stroke-L) var(--stroke-C) 280);
 
   // Named background colors (should contrast well with text color)
-  --bg-L: 70%; // Background intensity
-  --bg-S: 100%; // Background saturation
-  --bg-dark-L: 50%; // Dark bg intensity
-  --bg-dark-S: 60%; // Dark bg saturation
+  --bg-L: 70%; // Background lightness
+  --bg-C: 50%; // Background chroma
+  --bg-dark-L: 40%; // Dark bg lightness
+  --bg-dark-C: 50%; // Dark bg chroma
 
-  --bg-blue: hsl(180, var(--bg-S), var(--bg-L));
-  --bg-green: hsl(120, var(--bg-S), var(--bg-L));
-  --bg-indigo: hsl(240, var(--bg-S), var(--bg-L));
-  --bg-orange: hsl(30, var(--bg-S), var(--bg-L));
-  --bg-red: hsl(0, var(--bg-S), var(--bg-L));
-  --bg-violet: hsl(300, var(--bg-S), var(--bg-L));
-  --bg-yellow: hsl(60, var(--bg-S), var(--bg-L));
+  --bg-red: oklch(var(--bg-L) var(--bg-C) 20);
+  --bg-orange: oklch(var(--bg-L) var(--bg-C) 60);
+  --bg-yellow: oklch(var(--bg-L) var(--bg-C) 90);
+  --bg-green: oklch(var(--bg-L) var(--bg-C) 150);
+  --bg-blue: oklch(var(--bg-L) var(--bg-C) 220);
+  --bg-indigo: oklch(var(--bg-L) var(--bg-C) 250);
+  --bg-violet: oklch(var(--bg-L) var(--bg-C) 280);
 
-  --bg-darkblue: hsl(180, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkgreen: hsl(120, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkindigo: hsl(240, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkorange: hsl(30, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkred: hsl(0, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkviolet: hsl(300, var(--bg-dark-S), var(--bg-dark-L));
-  --bg-darkyellow: hsl(60, var(--bg-dark-S), var(--bg-dark-L));
+  --bg-dark-red: oklch(var(--bg-dark-L) var(--bg-dark-C) 20);
+  --bg-dark-orange: oklch(var(--bg-dark-L) var(--bg-dark-C) 60);
+  --bg-dark-yellow: oklch(var(--bg-dark-L) var(--bg-dark-C) 90);
+  --bg-dark-green: oklch(var(--bg-dark-L) var(--bg-dark-C) 150);
+  --bg-dark-blue: oklch(var(--bg-dark-L) var(--bg-dark-C) 220);
+  --bg-dark-indigo: oklch(var(--bg-dark-L) var(--bg-dark-C) 250);
+  --bg-dark-violet: oklch(var(--bg-dark-L) var(--bg-dark-C) 280);
 
   --transition-duration: 0.5s;
 }
@@ -75,7 +75,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     @for $i from 0 through 10 {
-      --grey#{(10-$i) * 10}: hsl(0, 0%, #{$i * 10%});
+      --grey#{(10-$i) * 10}: oklch(#{$i * 10%} 0 0);
     }
 
     --root-color: black; // Don't change, it's used to mix colors on light/dark schemes
@@ -86,9 +86,10 @@
     --bg1: #696666;
     --bg2: #333;
 
-    --stroke-L: 60%;
-    --bg-L: 30%;
-    --bg-dark-L: 40%;
+    --stroke-L: 50%;
+    --bg-L: 50%;
+    --bg-C: 50%;
+    --bg-dark-L: 30%;
   }
 }
 

--- a/index.scss
+++ b/index.scss
@@ -34,7 +34,7 @@
   --text-on-accent: #fff;
 
   // Shadow colors depend on the background color
-  --bg0-shadow-color: color-mix(in hsl, var(--bg0) 90%, black);
+  --bg0-shadow-color: color-mix(in oklch, var(--bg0) 90%, black);
 
   // Named stroke colors (for borders and lines that should contrast well with background colors)
   --stroke-L: 70%;

--- a/index.scss
+++ b/index.scss
@@ -38,32 +38,32 @@
 
   // Named stroke colors (for borders and lines that should contrast well with background colors)
   --stroke-L: 70%;
-  --stroke-C: 50%;
+  --stroke-C: 100%;
   --stroke-red: oklch(var(--stroke-L) var(--stroke-C) 20);
-  --stroke-orange: oklch(var(--stroke-L) var(--stroke-C) 60);
-  --stroke-yellow: oklch(var(--stroke-L) var(--stroke-C) 90);
+  --stroke-orange: oklch(var(--stroke-L) var(--stroke-C) 75);
+  --stroke-yellow: oklch(var(--stroke-L) var(--stroke-C) 110);
   --stroke-green: oklch(var(--stroke-L) var(--stroke-C) 150);
   --stroke-blue: oklch(var(--stroke-L) var(--stroke-C) 220);
   --stroke-indigo: oklch(var(--stroke-L) var(--stroke-C) 250);
   --stroke-violet: oklch(var(--stroke-L) var(--stroke-C) 280);
 
   // Named background colors (should contrast well with text color)
-  --bg-L: 70%; // Background lightness
-  --bg-C: 50%; // Background chroma
+  --bg-L: 80%; // Background lightness
+  --bg-C: 70%; // Background chroma
   --bg-dark-L: 40%; // Dark bg lightness
   --bg-dark-C: 50%; // Dark bg chroma
 
   --bg-red: oklch(var(--bg-L) var(--bg-C) 20);
-  --bg-orange: oklch(var(--bg-L) var(--bg-C) 60);
-  --bg-yellow: oklch(var(--bg-L) var(--bg-C) 90);
+  --bg-orange: oklch(var(--bg-L) var(--bg-C) 75);
+  --bg-yellow: oklch(var(--bg-L) var(--bg-C) 110);
   --bg-green: oklch(var(--bg-L) var(--bg-C) 150);
   --bg-blue: oklch(var(--bg-L) var(--bg-C) 220);
   --bg-indigo: oklch(var(--bg-L) var(--bg-C) 250);
   --bg-violet: oklch(var(--bg-L) var(--bg-C) 280);
 
   --bg-dark-red: oklch(var(--bg-dark-L) var(--bg-dark-C) 20);
-  --bg-dark-orange: oklch(var(--bg-dark-L) var(--bg-dark-C) 60);
-  --bg-dark-yellow: oklch(var(--bg-dark-L) var(--bg-dark-C) 90);
+  --bg-dark-orange: oklch(var(--bg-dark-L) var(--bg-dark-C) 75);
+  --bg-dark-yellow: oklch(var(--bg-dark-L) var(--bg-dark-C) 110);
   --bg-dark-green: oklch(var(--bg-dark-L) var(--bg-dark-C) 150);
   --bg-dark-blue: oklch(var(--bg-dark-L) var(--bg-dark-C) 220);
   --bg-dark-indigo: oklch(var(--bg-dark-L) var(--bg-dark-C) 250);
@@ -86,7 +86,7 @@
     --bg1: #696666;
     --bg2: #333;
 
-    --stroke-L: 50%;
+    --stroke-L: 80%;
     --bg-L: 50%;
     --bg-C: 50%;
     --bg-dark-L: 30%;

--- a/lib/LoadActivity.ts
+++ b/lib/LoadActivity.ts
@@ -13,10 +13,6 @@ export default class LoadActivity {
   active = 0;
   onChange: LoadActivityFn | null = null;
 
-  get percent() {
-    return `${(1 - this.active / this.total) * 100}%`;
-  }
-
   start(title: string): () => void {
     if (title) this.title = title;
     this.total++;

--- a/lib/dom.ts
+++ b/lib/dom.ts
@@ -20,3 +20,7 @@ export function cn(...args: (string | object | undefined)[]) {
 
   return Array.from(classes).join(' ');
 }
+
+export function percent(n: number, precision = 3) {
+  return `${(n * 100).toPrecision(precision)}%`;
+}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -9,13 +9,6 @@ declare module 'bundle-text:*' {
 // reason TS types the exports as `any`, despite the default export provided
 // below.
 
-declare module '*.module.css' {
-  const styles: Record<string, string>;
-  export default styles;
-}
-declare module '*.module.scss' {
-  const styles: Record<string, string>;
-  export default styles;
-}
-
+declare module '*.module.css';
+declare module '*.module.scss';
 declare module 'jsx:*';

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -5,6 +5,17 @@ declare module 'bundle-text:*' {
   export default value;
 }
 
-declare module '*.module.css';
-declare module '*.module.scss';
+// Providing types for css modules here.  This works... sort of.  For some
+// reason TS types the exports as `any`, despite the default export provided
+// below.
+
+declare module '*.module.css' {
+  const styles: Record<string, string>;
+  export default styles;
+}
+declare module '*.module.scss' {
+  const styles: Record<string, string>;
+  export default styles;
+}
+
 declare module 'jsx:*';


### PR DESCRIPTION
Found myself fiddling with colors in the colorizer legends while working on #326, and ended up going all-in on the `oklch`. This is admittedly a bit of an experiment, an excuse to learn about the `oklch` colorspace.  It's [kinda weird](https://lch.oklch.com/#0.576,78.78,216.36,100), but has the advantage of providing colors with a consistent brightness when you vary the H(ue) value.

Also fixing up a few odds and ends that I turned up along the way ...
* NPMSIO colorizer legend uses CSS gradient with `scoreColor()` computed endpoints
* Use `color-mix` for color interpolation
* Tweaks to colors and styling in release timeline chart
* Wider color variation in treemap

@fregante: The tl;dr: is "a bit more color"...

Before:
![CleanShot 2025-06-16 at 10 29 17](https://github.com/user-attachments/assets/44b4c0f1-1d14-4369-b336-a02dab6cc74f)

After:
![CleanShot 2025-06-16 at 10 30 19](https://github.com/user-attachments/assets/ca11bf8a-99a6-4190-bbf4-f3b8d732fd9c)
