### PR TITLE
feat: report module-replacements

### DIFF
--- a/components/GraphPane/GraphPane.tsx
+++ b/components/GraphPane/GraphPane.tsx
@@ -21,6 +21,7 @@ import { licensesKeyword } from './reports/reporters/licensesKeyword.js';
 import { licensesMissing } from './reports/reporters/licensesMissing.js';
 import { maintainersAll } from './reports/reporters/maintainersAll.js';
 import { maintainersSolo } from './reports/reporters/maintainersSolo.js';
+import { moduleReplacementsNative } from './reports/reporters/moduleReplacements.js';
 import { modulesAll } from './reports/reporters/modulesAll.js';
 import { modulesDeprecated } from './reports/reporters/modulesDeprecated.js';
 import { modulesRepeated } from './reports/reporters/modulesRepeated.js';
@@ -102,6 +103,14 @@ export default function GraphPane({
 
       <ReportSection title="Modules">
         <ReportItem data={moduleAnalysis} reporter={modulesAll} />
+
+        <ReportItem data={moduleAnalysis} reporter={moduleReplacementsNative}>
+          From the{' '}
+          <ExternalLink href="https://github.com/es-tooling/module-replacements">
+            module-replacements
+          </ExternalLink>{' '}
+          project, these modules can be removed or replaced with more modern, streamlined alternatives
+        </ReportItem>
 
         <ReportItem data={moduleAnalysis} reporter={modulesRepeated}>
           Module repetition is a result of incompatible version constraints, and

--- a/components/GraphPane/reports/Analyzer.tsx
+++ b/components/GraphPane/reports/Analyzer.tsx
@@ -23,8 +23,7 @@ export type RenderedAnalysis =
       type: 'info' | 'warn' | 'error';
       summary: string;
       details: ReactElement[];
-    }
-  | undefined;
+    };
 
 export abstract class Analyzer {
   constructor(public graph: GraphState) {}

--- a/components/GraphPane/reports/reporters/licensesAll.tsx
+++ b/components/GraphPane/reports/reporters/licensesAll.tsx
@@ -8,7 +8,7 @@ import * as styles from './licensesAll.module.scss';
 
 export function licensesAll({
   modulesByLicense,
-}: LicenseAnalysisState): RenderedAnalysis {
+}: LicenseAnalysisState) {
   const details = Array.from(modulesByLicense.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([license, modules]) => {
@@ -45,5 +45,5 @@ export function licensesAll({
   if (details.length <= 0) return;
 
   const summary = simplur`All licenses (${details.length})`;
-  return { type: 'info', summary, details };
+  return { type: 'info', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/licensesKeyword.tsx
+++ b/components/GraphPane/reports/reporters/licensesKeyword.tsx
@@ -9,9 +9,9 @@ import * as styles from './modulesAll.module.scss';
 export function licensesKeyword(keyword: OSIKeyword) {
   return function ({
     modulesByKeyword,
-  }: LicenseAnalysisState): RenderedAnalysis {
+  }: LicenseAnalysisState) {
     const modules = modulesByKeyword.get(keyword);
-    if (!modules) return;
+    if (!modules) return undefined;
 
     const summary = simplur`Modules with "${keyword}" license (${modules.length})`;
 
@@ -27,6 +27,6 @@ export function licensesKeyword(keyword: OSIKeyword) {
         </div>
       ));
 
-    return { type: 'warn', summary, details };
+    return { type: 'warn', summary, details } as RenderedAnalysis;
   };
 }

--- a/components/GraphPane/reports/reporters/licensesMissing.tsx
+++ b/components/GraphPane/reports/reporters/licensesMissing.tsx
@@ -3,9 +3,7 @@ import { Selectable } from '../../../Selectable.js';
 import type { RenderedAnalysis } from '../Analyzer.js';
 import type { LicenseAnalysisState } from '../analyzeLicenses.js';
 
-export function licensesMissing({
-  unlicensedModules,
-}: LicenseAnalysisState): RenderedAnalysis {
+export function licensesMissing({ unlicensedModules }: LicenseAnalysisState) {
   if (!unlicensedModules.length) return;
 
   const summary = simplur`Unlicensed modules (${unlicensedModules.length})`;
@@ -18,5 +16,5 @@ export function licensesMissing({
       </div>
     ));
 
-  return { type: 'warn', summary, details };
+  return { type: 'warn', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/maintainersAll.tsx
+++ b/components/GraphPane/reports/reporters/maintainersAll.tsx
@@ -10,7 +10,7 @@ import * as styles from './maintainersAll.module.scss';
 export function maintainersAll({
   modulesByMaintainer,
   emailByMaintainer,
-}: MaintainerAnalysisState): RenderedAnalysis {
+}: MaintainerAnalysisState) {
   const details = Array.from(modulesByMaintainer.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([name, modules]) => {
@@ -44,5 +44,5 @@ export function maintainersAll({
   if (details.length <= 0) return;
 
   const summary = simplur`All maintainers (${details.length})`;
-  return { type: 'info', summary, details };
+  return { type: 'info', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/maintainersSolo.tsx
+++ b/components/GraphPane/reports/reporters/maintainersSolo.tsx
@@ -7,7 +7,7 @@ export function maintainersSolo({
   soloModulesByMaintainer,
   soloModulesCount,
   emailByMaintainer,
-}: MaintainerAnalysisState): RenderedAnalysis {
+}: MaintainerAnalysisState) {
   // Use renderAll logic, but with only the subset of data for solo maintainers
   const results = maintainersAll({
     modulesByMaintainer: soloModulesByMaintainer,
@@ -22,5 +22,5 @@ export function maintainersSolo({
     type: 'warn',
     summary: simplur`Modules with only one maintainer (${soloModulesCount})`,
     details: results.details,
-  };
+  } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/moduleReplacements.module.scss
+++ b/components/GraphPane/reports/reporters/moduleReplacements.module.scss
@@ -1,0 +1,22 @@
+.root {
+  margin-block-end: 0.5rem;
+  line-height: 1.5rem;
+
+  .body {
+    display: block;
+    margin-left: 1rem;
+    font-style: italic;
+  }
+
+  .body code {
+    color: var(--text-dim);
+    font-style: normal;
+    font-weight: bold;
+  }
+
+  :global {
+    .selectable {
+      margin-inline-end: 0;
+    }
+  }
+}

--- a/components/GraphPane/reports/reporters/moduleReplacements.tsx
+++ b/components/GraphPane/reports/reporters/moduleReplacements.tsx
@@ -1,0 +1,100 @@
+import type { ModuleReplacement } from 'module-replacements';
+import microUtilities from 'module-replacements/manifests/micro-utilities.json' with { type: 'json' };
+import native from 'module-replacements/manifests/native.json' with { type: 'json' };
+import preferred from 'module-replacements/manifests/preferred.json' with { type: 'json' };
+import { cn } from '../../../../lib/dom.js';
+import { ExternalLink } from '../../../ExternalLink.js';
+import { Selectable } from '../../../Selectable.js';
+import type { RenderedAnalysis } from '../Analyzer.js';
+import type { ModuleAnalysisState } from '../analyzeModules.js';
+import * as styles from './moduleReplacements.module.scss';
+
+const REPLACEMENTS = new Map<string, ModuleReplacement>();
+for (const { moduleReplacements } of [native, microUtilities, preferred]) {
+  for (const replacement of moduleReplacements) {
+    if (REPLACEMENTS.has(replacement.moduleName)) {
+      console.warn(
+        'DUPLICATE REPLACEMENT',
+        replacement.moduleName,
+        replacement,
+      );
+    } else {
+      REPLACEMENTS.set(
+        replacement.moduleName,
+        replacement as ModuleReplacement,
+      );
+    }
+  }
+}
+
+for (const r of REPLACEMENTS.values()) {
+  console.log(r.category, r.type);
+}
+
+export function moduleReplacementsNative({
+  moduleInfos,
+  // entryModules,
+}: ModuleAnalysisState) {
+  const replacements = new Array<ModuleReplacement>();
+  for (const [_, info] of moduleInfos) {
+    const replacement = REPLACEMENTS.get(info.module.name);
+    if (replacement) {
+      replacements.push(replacement);
+    }
+  }
+
+  const details = Array.from(moduleInfos.values())
+    .filter(info => REPLACEMENTS.has(info.module.name))
+    .sort((a, b) => a.module.key.localeCompare(b.module.key))
+    .map(({ module }) => {
+      const r = REPLACEMENTS.get(module.name);
+      let detail;
+
+      switch (r?.type) {
+        case 'native':
+          detail = (
+            <>
+              Use native{' '}
+              <ExternalLink
+                href={`https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/${r.mdnPath}`}
+              >
+                {r.replacement}
+              </ExternalLink>
+            </>
+          );
+          break;
+
+        case 'simple':
+          detail = <>{r.replacement}</>;
+          break;
+
+        case 'documented':
+          detail = (
+            <>
+              See{' '}
+              <ExternalLink
+                href={`https://github.com/es-tooling/module-replacements/tree/main/docs/modules/${r.docPath}.md`}
+              >
+                {r.moduleName} notes
+              </ExternalLink>
+            </>
+          );
+      }
+
+      return (
+        <div className={cn(styles.root, 'zebra-row')} key={module.key}>
+          <Selectable type="exact" value={module.key} />
+          {': '}
+          <span className={styles.body}>{detail}</span>
+        </div>
+      );
+    });
+
+  if (replacements.length === 0) return;
+
+  return {
+    type: 'warn',
+    summary: `Suggested replacements (${replacements.length})`,
+    details,
+  } as RenderedAnalysis;
+}

--- a/components/GraphPane/reports/reporters/modulesAll.tsx
+++ b/components/GraphPane/reports/reporters/modulesAll.tsx
@@ -8,7 +8,7 @@ import * as styles from './modulesAll.module.scss';
 export function modulesAll({
   moduleInfos,
   entryModules,
-}: ModuleAnalysisState): RenderedAnalysis {
+}: ModuleAnalysisState) {
   if (moduleInfos.size === 0) {
     return;
   }
@@ -33,5 +33,5 @@ export function modulesAll({
     moduleInfos.size - entryModules.size
   } dependenc[y|ies])`;
 
-  return { type: 'info', summary, details };
+  return { type: 'info', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/modulesDeprecated.tsx
+++ b/components/GraphPane/reports/reporters/modulesDeprecated.tsx
@@ -7,7 +7,7 @@ import * as styles from './modulesDeprecated.module.scss';
 
 export function modulesDeprecated({
   deprecated,
-}: ModuleAnalysisState): RenderedAnalysis {
+}: ModuleAnalysisState) {
   if (deprecated.length <= 0) return;
 
   const details = deprecated
@@ -25,5 +25,5 @@ export function modulesDeprecated({
     });
 
   const summary = simplur`Deprecated modules (${deprecated.length})`;
-  return { type: 'warn', summary, details };
+  return { type: 'warn', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/modulesRepeated.tsx
+++ b/components/GraphPane/reports/reporters/modulesRepeated.tsx
@@ -7,7 +7,7 @@ import * as styles from './modulesRepeated.module.scss';
 
 export function modulesRepeated({
   moduleInfos,
-}: ModuleAnalysisState): RenderedAnalysis {
+}: ModuleAnalysisState) {
   const versionsByName: Record<string, string[]> = {};
 
   moduleInfos.forEach(({ module }) => {
@@ -40,5 +40,5 @@ export function modulesRepeated({
 
   const summary = simplur`Modules with multiple versions (${details.length})`;
 
-  return { type: 'warn', summary, details };
+  return { type: 'warn', summary, details } as RenderedAnalysis;
 }

--- a/components/GraphPane/reports/reporters/peerDependenciesAll.tsx
+++ b/components/GraphPane/reports/reporters/peerDependenciesAll.tsx
@@ -9,7 +9,7 @@ import * as styles from './peerDependenciesAll.module.scss';
 
 export function peerDependenciesAll({
   peerDependencyInfos,
-}: PeerDependenciesState): RenderedAnalysis {
+}: PeerDependenciesState) {
   if (!peerDependencyInfos.length) return;
 
   // @ts-expect-error Unignore once TS types know about Map.groupBy()
@@ -68,12 +68,12 @@ export function peerDependenciesAll({
 
   const summary = `All peer dependencies (${peerDependencyInfos.length})`;
 
-  return { type: 'info', summary, details };
+  return { type: 'info', summary, details } as RenderedAnalysis;
 }
 
 export function peerDependenciesMissing({
   peerDependencyInfos,
-}: PeerDependenciesState): RenderedAnalysis {
+}: PeerDependenciesState) {
   const missingInfos = peerDependencyInfos.filter(
     pdi => !pdi.destination && !pdi.optional,
   );
@@ -84,5 +84,5 @@ export function peerDependenciesMissing({
     type: 'warn',
     summary: `Missing peer dependencies (${missingInfos.length})`,
     details: result?.details,
-  };
+  } as RenderedAnalysis;
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       fonts.googleapis.com
       fonts.gstatic.com
       notify.bugsnag.com
+      raw.githubusercontent.com
       sessions.bugsnag.com
       www.google-analytics.com
       www.googletagmanager.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "d3-shape": "3.2.0",
         "filter-altered-clicks": "2.1.1",
         "md5": "2.3.0",
+        "module-replacements": "2.8.0",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "select-dom": "^9.3.1",
@@ -56,6 +57,7 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "npm-run-all2": "^8.0.4",
         "parcel": "^2.15.2",
+        "path-browserify": "1.0.1",
         "postcss": "8.5.6",
         "postcss-modules": "6.0.1",
         "prettier": "3.5.3",
@@ -65,7 +67,8 @@
         "svgo": "3.3.2",
         "typed-query-selector": "^2.12.0",
         "typescript": "5.8.3",
-        "typescript-plugin-css-modules": "^5.1.0"
+        "typescript-plugin-css-modules": "^5.1.0",
+        "url": "0.11.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4639,6 +4642,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5844,6 +5878,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.169",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.169.tgz",
@@ -5923,6 +5972,39 @@
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -7169,6 +7251,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-pkg-repo": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
@@ -7263,6 +7370,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -7415,6 +7536,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7465,6 +7599,19 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -8475,6 +8622,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/md5": {
@@ -9662,6 +9819,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/module-replacements": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.8.0.tgz",
+      "integrity": "sha512-ecTdT19nf+jYxPhXNCUuopDwazNOfcEW/GVlRmVxFO/zWcFFedso+pV4GbJ0TKjI+su3htyghhCJJ99ZAkuUyg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9949,6 +10112,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10126,6 +10302,13 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
       "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
@@ -10564,6 +10747,22 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/quansync": {
@@ -11148,6 +11347,82 @@
       "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
       "dev": true,
       "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11974,6 +12249,27 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "d3-shape": "3.2.0",
     "filter-altered-clicks": "2.1.1",
     "md5": "2.3.0",
+    "module-replacements": "2.8.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "select-dom": "^9.3.1",
@@ -90,6 +91,7 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "npm-run-all2": "^8.0.4",
     "parcel": "^2.15.2",
+    "path-browserify": "1.0.1",
     "postcss": "8.5.6",
     "postcss-modules": "6.0.1",
     "prettier": "3.5.3",
@@ -99,6 +101,7 @@
     "svgo": "3.3.2",
     "typed-query-selector": "^2.12.0",
     "typescript": "5.8.3",
-    "typescript-plugin-css-modules": "^5.1.0"
+    "typescript-plugin-css-modules": "^5.1.0",
+    "url": "0.11.4"
   }
 }


### PR DESCRIPTION
Adds a "Suggested replacements" report on the graph pane, showing which packages may be removed or replaced with better alternatives per the `module-replacements` project.

> [NOTE!]
> For the time being, the list of replaceable packages is built into the project and will need to be updated manually from time to time.  At some point this could be automated, but not worth worrying about right now.

Closes #299 